### PR TITLE
add support for listing Force.com API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,19 @@ A command-line interface to force.com
 	Usage: force <command> [<args>]
 	
 	Available commands:
-	   login     Log in to force.com
-	   logout    Log out from force.com
-	   accounts  List force.com accounts
-	   active    Show or set the active force.com account
-	   whoami    Show information about the active account
-	   sobject   Manage custom objects
-	   field     Manage custom fields
-	   record    Create, modify, or view records
-	   select    Execute a SOQL select
-	   apex      Execute anonymous Apex code
-	   version   Display current version
-	   update    Update to the latest version
-	   help      Show this help
+	   login       Log in to force.com
+	   logout      Log out from force.com
+	   apiversion  Manage Force.com API versions
+	   accounts    List force.com accounts
+	   active      Show or set the active force.com account
+	   whoami      Show information about the active account
+	   sobject     Manage custom objects
+	   field       Manage custom fields
+	   record      Create, modify, or view records
+	   select      Execute a SOQL select
+	   apex        Execute anonymous Apex code
+	   version     Display current version
+	   update      Update to the latest version
+	   help        Show this help
 	
 	Run 'force help [command]' for details.

--- a/apiversions.go
+++ b/apiversions.go
@@ -1,0 +1,37 @@
+package main
+
+var cmdAPIVersion = &Command{
+	Run:   runAPIVersion,
+	Usage: "apiversion",
+	Short: "Manage Force.com API versions",
+	Long: `
+Manage Force.com API versions
+
+Usage:
+
+  force apiversion list
+`,
+}
+
+func runAPIVersion(cmd *Command, args []string) {
+	if len(args) == 0 {
+		cmd.printUsage()
+	} else {
+		switch args[0] {
+		case "list":
+			runAPIVersionList()
+		default:
+			ErrorAndExit("no such command: %s", args[0])
+		}
+	}
+}
+
+func runAPIVersionList() {
+	force, _ := ActiveForce()
+	records, err := force.ListAPIVersions()
+	if err != nil {
+		ErrorAndExit(err.Error())
+	} else {
+	  DisplayVersionRecords(records)	
+	}
+}

--- a/display.go
+++ b/display.go
@@ -60,6 +60,12 @@ func DisplayForceRecord(record ForceRecord) {
 	DisplayInterfaceMap(record, 0)
 }
 
+func DisplayVersionRecords(versions []ForceVersion) {
+	for _, version := range versions {
+		fmt.Printf("%s - %s\n", version.Version, version.Label)
+	}
+}
+
 func DisplayInterfaceMap(object map[string]interface{}, indent int) {
 	keys := make([]string, len(object))
 	i := 0

--- a/force.go
+++ b/force.go
@@ -111,6 +111,12 @@ type ForceSobjectsResult struct {
 	Sobjects     []ForceSobject
 }
 
+type ForceVersion struct {
+	Version string
+	Label		string
+	URL 		string
+}
+
 func NewForce(creds ForceCredentials) (force *Force) {
 	force = new(Force)
 	force.Credentials = creds
@@ -135,6 +141,16 @@ func ForceLogin(endpoint ForceEndpoint) (creds ForceCredentials, err error) {
 	}
 	err = Open(url)
 	creds = <-ch
+	return
+}
+
+func (f *Force) ListAPIVersions() (versions []ForceVersion, err error) {
+	url := fmt.Sprintf("%s/services/data/", f.Credentials.InstanceUrl)
+	body, err := f.httpGet(url)
+	if err != nil {
+		return
+	}
+	json.Unmarshal(body, &versions)
 	return
 }
 

--- a/help.go
+++ b/help.go
@@ -41,7 +41,7 @@ var usageTemplate = template.Must(template.New("usage").Parse(`
 Usage: force <command> [<args>]
 
 Available commands:{{range .Commands}}{{if .Runnable}}{{if .List}}
-   {{.Name | printf "%-8s"}}  {{.Short}}{{end}}{{end}}{{end}}
+   {{.Name | printf "%-12s"}}  {{.Short}}{{end}}{{end}}{{end}}
 
 Run 'force help [command]' for details.
 `[1:]))

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 var commands = []*Command{
 	cmdLogin,
 	cmdLogout,
+	cmdAPIVersion,
 	cmdAccounts,
 	cmdActive,
 	cmdWhoami,


### PR DESCRIPTION
Almost all interactions with the Force.com API use a version number, for example `services/data/v29.0/limits`

That v29.0 is the version number.

This PR adds support for listing these version numbers and their associated names, like `Winter '11` - see the example below.

I envision a future where there will be another command, `force apiversions set 25.0`.  Then this client should perform interactions using that version (25.0).  Right now, `force.com` hard codes it to v20.0, which is really old.

Example:
    $ force apiversions list
    20.0 - Winter '11
    21.0 - Spring '11
    22.0 - Summer '11
    23.0 - Winter '12
    24.0 - Spring '12
    25.0 - Summer '12
    26.0 - Winter '13
    27.0 - Spring '13
    28.0 - Summer '13
    29.0 - Winter '14
