### PR TITLE
Add support for parent + child relationship SOQL queries

### DIFF
--- a/display.go
+++ b/display.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,6 +19,12 @@ func DisplayForceSobjects(sobjects []ForceSobject) {
 }
 
 func DisplayForceRecords(records []ForceRecord) {
+	fmt.Println(RenderForceRecords(records))
+}
+
+func RenderForceRecords(records []ForceRecord) string {
+	var out bytes.Buffer
+
 	var keys []string
 	var flattenedRecords []map[string]interface{}
 	for _, record := range records {
@@ -37,7 +44,11 @@ func DisplayForceRecords(records []ForceRecord) {
 		for i, key := range keys {
 			lengths[i] = len(key)
 			for _, record := range flattenedRecords {
-				l := len(fmt.Sprintf("%v", record[key]))
+				v := fmt.Sprintf("%v", record[key])
+				l := len(v)
+				if index := strings.Index(v, "\n"); index > -1 {
+					l = index + 1
+				}
 				if l > lengths[i] {
 					lengths[i] = l
 				}
@@ -49,18 +60,36 @@ func DisplayForceRecords(records []ForceRecord) {
 			formatter_parts[i] = fmt.Sprintf(" %%-%ds ", length)
 		}
 		formatter := strings.Join(formatter_parts, "|")
-		fmt.Printf(formatter+"\n", StringSliceToInterfaceSlice(keys)...)
-		fmt.Printf(strings.Join(separators, "+") + "\n")
+		out.WriteString(fmt.Sprintf(formatter+"\n", StringSliceToInterfaceSlice(keys)...))
+		out.WriteString(fmt.Sprintf(strings.Join(separators, "+") + "\n"))
 		for _, record := range flattenedRecords {
-			values := make([]string, len(keys))
+			values := make([][]string, len(keys))
 			for i, key := range keys {
-				values[i] = fmt.Sprintf("%v", record[key])
+				values[i] = strings.Split(fmt.Sprintf("%v", record[key]), "\n")
 			}
-			fmt.Printf(formatter+"\n", StringSliceToInterfaceSlice(values)...)
+
+			maxLines := 0
+			for _, value := range values {
+				lines := len(value)
+				if lines > maxLines {
+					maxLines = lines
+				}
+			}
+
+			for li := 0; li < maxLines; li++ {
+				line := make([]string, len(values))
+				for i, value := range values {
+					if len(value) > li {
+						line[i] = value[li]
+					}
+				}
+				out.WriteString(fmt.Sprintf(formatter+"\n", StringSliceToInterfaceSlice(line)...))
+			}
 		}
-		fmt.Printf(strings.Join(separators, "+") + "\n")
+		out.WriteString(fmt.Sprintf(strings.Join(separators, "+") + "\n"))
 	}
-	fmt.Printf(" (%d records)\n", len(records))
+	out.WriteString(fmt.Sprintf(" (%d records)\n", len(records)))
+	return out.String()
 }
 
 func FlattenForceRecord(record ForceRecord) map[string]interface{} {
@@ -70,14 +99,28 @@ func FlattenForceRecord(record ForceRecord) map[string]interface{} {
 		if key == "attributes" {
 			continue
 		} else if relationship, isRelationship := value.(map[string]interface{}); isRelationship {
-			for subKey, subValue := range FlattenForceRecord(relationship) {
-				fieldValues[key+"."+subKey] = subValue
+			if _, ok := relationship["records"]; ok {
+				fieldValues[key] = RenderForceRecords(ChildRelationshipToQueryResult(relationship).Records)
+			} else {
+				for parentKey, parentValue := range FlattenForceRecord(relationship) {
+					fieldValues[key+"."+parentKey] = parentValue
+				}
 			}
 		} else {
 			fieldValues[key] = value
 		}
 	}
 	return fieldValues
+}
+
+func ChildRelationshipToQueryResult(relationship map[string]interface{}) ForceQueryResult {
+	done := relationship["done"].(bool)
+	var records []ForceRecord
+	for _, cr := range relationship["records"].([]interface{}) {
+		records = append(records, ForceRecord(cr.(map[string]interface{})))
+	}
+	totalSize := int(relationship["totalSize"].(float64))
+	return ForceQueryResult{done, records, totalSize}
 }
 
 func StringSliceContains(slice []string, e string) bool {


### PR DESCRIPTION
**See Pull Request #7 first for background and info about parent relationship query support**

This change supersedes Pull Request #7 for just parent relationship queries and adds supports for child relationship queries as well. Similar to parent relationship queries, child relationships are returned as nested results; however, instead of being nested sobjects, they are nested query results and are best displayed as nested tables. For example:

```
force select "id, name, (select id, name, createdby.name from contacts) from account where id in (select accountid from contact) limit 2"
 Id                 | Name   | Contacts
--------------------+--------+--------------------------------------------------------
 0016000000K7NdWAAV | Google |  Id                 | Name        | CreatedBy.Name
                    |        | --------------------+-------------+----------------
                    |        |  0036000000q0ab9AAA | Larry Page  | Ryan Brainard
                    |        |  0036000000pXGQjAAO | Sergey Brin | Ryan Brainard
                    |        | --------------------+-------------+----------------
                    |        |  (2 records)
                    |        |
 0016000000Khr6YAAR | Yahoo! |  Id                 | Name          | CreatedBy.Name
                    |        | --------------------+---------------+----------------
                    |        |  0036000000qCwxyAAC | Marissa Mayer | Ryan Brainard
                    |        | --------------------+---------------+----------------
                    |        |  (1 records)
                    |        |
--------------------+--------+--------------------------------------------------------
 (2 records)
```

Note in the example that this also supports child relationships looking back up to parent relationships with the display of `Contacts.CreatedBy.Name`.
