### PR TITLE
move defer calls to after error check to avoid panic

### DIFF
--- a/force.go
+++ b/force.go
@@ -260,10 +260,10 @@ func (f *Force) httpPost(url string, attrs map[string]string) (body []byte, err 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
 	res, err := httpClient().Do(req)
-	defer res.Body.Close()
 	if err != nil {
 		return
 	}
+	defer res.Body.Close()
 	if res.StatusCode == 401 {
 		err = errors.New("authorization expired, please run `force login`")
 		return
@@ -287,10 +287,10 @@ func (f *Force) httpPatch(url string, attrs map[string]string) (body []byte, err
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
 	res, err := httpClient().Do(req)
-	defer res.Body.Close()
 	if err != nil {
 		return
 	}
+	defer res.Body.Close()
 	if res.StatusCode == 401 {
 		err = errors.New("authorization expired, please run `force login`")
 		return
@@ -312,10 +312,10 @@ func (f *Force) httpDelete(url string) (body []byte, err error) {
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	res, err := httpClient().Do(req)
-	defer res.Body.Close()
 	if err != nil {
 		return
 	}
+	defer res.Body.Close()
 	if res.StatusCode == 401 {
 		err = errors.New("authorization expired, please run `force login`")
 		return

--- a/soap.go
+++ b/soap.go
@@ -52,10 +52,10 @@ func (s *Soap) Execute(action, query string) (response []byte, err error) {
 	req.Header.Add("Content-Type", "text/xml")
 	req.Header.Add("SOAPACtion", action)
 	res, err := httpClient().Do(req)
-	defer res.Body.Close()
 	if err != nil {
 		return
 	}
+	defer res.Body.Close()
 	if res.StatusCode == 401 {
 		err = errors.New("authorization expired, please run `force login`")
 		return


### PR DESCRIPTION
I was getting a panic if my internet connection dropped or made a bad request to Salesforce. After doing some research ( http://stackoverflow.com/questions/16280176/go-panic-runtime-error-invalid-memory-address-or-nil-pointer-dereference ) I detected it was the defer call being made to Close() the HTTP Connection even if a connection didn't exist. This PR fixes this issue. 
