### PR TITLE
Add very basic first test

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/bmizerany/assert"
+	"testing"
+)
+
+// test that all avialable commands come with at least a name and short usage information
+func TestUsage(t *testing.T) {
+	for _, cmd := range commands {
+		assert.NotEqual(t, cmd.Name(), "")
+		assert.NotEqual(t, cmd.Short, "")
+	}
+}


### PR DESCRIPTION
Add a very basic first test case for Commands, ensuring they have at least a
name and short usage information.
