### PR TITLE
Fetch, query and import additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # Force CLI specific things
 force
 metadata
+
+*.json
+
+*.xml

--- a/fetch.go
+++ b/fetch.go
@@ -12,13 +12,15 @@ var cmdFetch = &Command{
 	Usage: "fetch <type> [<artifact name>]",
 	Short: "Export specified artifact(s) to a local directory",
 	Long: `
-Export specified artifact(s) to a local directory
+Export specified artifact(s) to a local directory. Use "package" type to retrieve an unmanaged package.
 
 Examples
 
   force fetch CustomObject Book__c Author__c
 
   force fetch CustomObject
+
+  force fetch package MyPackagedApp
 `,
 }
 

--- a/logins.go
+++ b/logins.go
@@ -24,7 +24,7 @@ func runLogins(cmd *Command, args []string) {
 	active, _ := ActiveLogin()
 	accounts, _ := Config.List("accounts")
 	if len(accounts) == 0 {
-		fmt.Println("no accounts")
+		fmt.Println("no logins")
 	} else {
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 1, 0, 1, ' ', 0)

--- a/metadata.go
+++ b/metadata.go
@@ -699,24 +699,13 @@ func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadata
 }
 
 func (fm *ForceMetadata) RetrievePackage(packageName string) (files ForceMetadataFiles, err error) {
-	fmt.Println(packageName)
 	soap := `
 		<retrieveRequest>
 			<apiVersion>29.0</apiVersion>
 			<packageNames>%s</packageNames>
 		</retrieveRequest>
 	`
-	/*soapType := `
-		<types>
-			<name>%s</name>
-			<members>%s</members>
-		</types>
-	`
-	types := ""
-	for _, element := range query {
-		types += fmt.Sprintf(soapType, element.Name, element.Members)
-	}*/
-	soap = fmt.Sprintf(soap, packageName);
+	soap = fmt.Sprintf(soap, packageName)
 	body, err := fm.soapExecute("retrieve", soap)
 	if err != nil {
 		return

--- a/partner.go
+++ b/partner.go
@@ -64,6 +64,19 @@ func (partner *ForcePartner) ExecuteAnonymous(apex string) (output string, err e
 	return
 }
 
+func (partner *ForcePartner) soapExecuteCore(action, query string) (response []byte, err error) {
+	login, err := partner.Force.Get(partner.Force.Credentials.Id)
+	if err != nil {
+		return
+	}
+	url := strings.Replace(login["urls"].(map[string]interface{})["partner"].(string), "{version}", "28.0", 1)
+	//url = strings.Replace(url, "/u/", "/s/", 1) // seems dirty
+	soap := NewSoap(url, "urn:partner.soap.sforce.com", partner.Force.Credentials.AccessToken)
+	soap.Header = "<apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>"
+	response, err = soap.Execute(action, query)
+	return
+}
+
 func (partner *ForcePartner) soapExecute(action, query string) (response []byte, err error) {
 	login, err := partner.Force.Get(partner.Force.Credentials.Id)
 	if err != nil {

--- a/query.go
+++ b/query.go
@@ -1,19 +1,23 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 )
 
 var cmdQuery = &Command{
 	Run:   runQuery,
-	Usage: "query <soql>",
-	Short: "Execute a SOQL query",
+	Usage: "query <soql> [format:<json, csv>]",
+	Short: "Execute a SOQL query, optionally specify output format",
 	Long: `
 Execute a SOQL query
 
 Examples:
 
   force query select id, name from user
+
+  force query select Id, FirstName, LastName From Contact format:json
 `,
 }
 
@@ -22,11 +26,24 @@ func runQuery(cmd *Command, args []string) {
 	if len(args) < 1 {
 		ErrorAndExit("must specify a query")
 	}
-	query := strings.Join(args, " ")
+	var query = ""
+	if args[len(args)-1] == "format:json" {
+		query = strings.Join(args[:len(args)-1], " ")
+	} else {
+		query = strings.Join(args, " ")
+	}
 	records, err := force.Query(query)
 	if err != nil {
 		ErrorAndExit(err.Error())
 	} else {
-		DisplayForceRecords(records)
+		if args[len(args)-1] == "format:json" {
+			d, err := json.MarshalIndent(records, "", " ")
+			if err != nil {
+				ErrorAndExit(err.Error())
+			}
+			fmt.Println(string(d))
+		} else {
+			DisplayForceRecords(records)
+		}
 	}
 }

--- a/soap.go
+++ b/soap.go
@@ -70,7 +70,11 @@ func (s *Soap) ExecuteLogin(username, password string) (response []byte, err err
 
 func (s *Soap) Execute(action, query string) (response []byte, err error) {
 	soap := `
-		<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cmd="%s" xmlns:apex="http://soap.sforce.com/2006/08/apex">
+		<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+		xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" 
+		xmlns:cmd="%s" 
+		xmlns:apex="http://soap.sforce.com/2006/08/apex">
 			<env:Header>
 				<cmd:SessionHeader>
 					<cmd:sessionId>%s</cmd:sessionId>
@@ -84,7 +88,8 @@ func (s *Soap) Execute(action, query string) (response []byte, err error) {
 			</env:Body>
 		</env:Envelope>
 	`
-	rbody := fmt.Sprintf(soap, s.Namespace, s.AccessToken, s.Header, action, s.Namespace, query, action)
+	rbody := fmt.Sprintf(soap, s.Namespace,
+		s.AccessToken, s.Header, action, s.Namespace, query, action)
 	req, err := httpRequest("POST", s.Endpoint, strings.NewReader(rbody))
 	if err != nil {
 		return

--- a/sobject.go
+++ b/sobject.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"html"
+	"io/ioutil"
+	"os"
 )
 
 var cmdSobject = &Command{
@@ -19,6 +24,7 @@ Usage:
 
   force sobject delete <object>
 
+  force sobject import
 Examples:
 
   force sobject list
@@ -40,6 +46,8 @@ func runSobject(cmd *Command, args []string) {
 			runSobjectCreate(args[1:])
 		case "delete", "remove":
 			runSobjectDelete(args[1:])
+		case "import":
+			runSobjectImport(args[1:])
 		default:
 			ErrorAndExit("no such command: %s", args[0])
 		}
@@ -79,4 +87,72 @@ func runSobjectDelete(args []string) {
 		ErrorAndExit(err.Error())
 	}
 	fmt.Println("Custom object deleted")
+}
+
+func runSobjectImport(args []string) {
+	var objectDef = `
+<cmd:sObjects> 
+	<cmd:type>%s</cmd:type>
+%s</cmd:sObjects>`
+
+	// Need to read the file into a query result structure
+	data, err := ioutil.ReadAll(os.Stdin)
+
+	var query ForceQueryResult
+	json.Unmarshal(data, &query)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+
+	var soapMsg = ""
+	var objectType = ""
+	for _, record := range query.Records {
+		var fields = ""
+		for key, _ := range record {
+			if key == "Id" {
+				continue
+			} else if key == "attributes" {
+				x := record[key].(map[string]interface{})
+				val, ok := x["type"]
+				if ok {
+					objectType, ok = val.(string)
+				}
+			} else {
+				if record[key] != nil {
+					fields += fmt.Sprintf("\t<%s>%s</%s>\n", key, html.EscapeString(record[key].(string)), key)
+				}
+			}
+		}
+		soapMsg += fmt.Sprintf(objectDef, objectType, fields)
+	}
+
+	force, _ := ActiveForce()
+	response, err := force.Partner.soapExecuteCore("create", soapMsg)
+
+	type errorData struct {
+		Fields     string `xml:"field"`
+		Message    string `xml:"message"`
+		StatusCode string `xml:"statusCode"`
+	}
+
+	type result struct {
+		Id      string      `xml:"id"`
+		Success bool        `xml:"success"`
+		Errors  []errorData `xml:"errors"`
+	}
+
+	var xmlresponse struct {
+		Results []result `xml:"Body>createResponse>result"`
+	}
+	xml.Unmarshal(response, &xmlresponse)
+
+	for i, res := range xmlresponse.Results {
+		if res.Success {
+			fmt.Printf("%s created successfully\n", res.Id)
+		} else {
+			for _, e := range res.Errors {
+				fmt.Printf("%s\n\t%s\n%s\n", e.StatusCode, e.Message, query.Records[i])
+			}
+		}
+	}
 }


### PR DESCRIPTION
etch.go - updated usage to indicate package access
logins.go - change message from "no accounts" to "no logins"
partner.go - added soapExecuteCore for core SOAP api namespace
accomodation.
query.go - added support for output format specification
sobject.go - added import function to import new data
