### PR TITLE
Add Travis CI and small test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go: 
+  - 1.1
+  - 1.2
+
+install:
+  - go get github.com/bmizerany/assert
+  - go get github.com/ddollar/dist
+  - go get github.com/ddollar/config
+  - go get bitbucket.org/pkg/inflect

--- a/logins_test.go
+++ b/logins_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/ddollar/config"
+	"testing"
+)
+
+var TestConfig = config.NewConfig("force")
+
+// test that SetActiveLogin in turn sets the "current account"
+func TestSetActiveLogin(t *testing.T) {
+	SetActiveLogin("clint")
+	account, _ := TestConfig.Load("current", "account")
+	assert.Equal(t, account, "clint")
+}


### PR DESCRIPTION
Adds a small test for `logins.go` , but more importantly adds TravisCI. I've already enabled this in the web hooks part of heroku/force so merging this should kick off [jobs over at travis-ci](https://travis-ci.org/heroku/force)
