### PR TITLE
Push enhancements

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -31,6 +31,7 @@ type ComponentFailure struct {
 	Deleted     bool   `xml:"deleted"`
 	FileName    string `xml:"fileName"`
 	FullName    string `xml:"fullName"`
+    LineNumber  int    `xml:"lineNumber"`
 	Problem     string `xml:"problem"`
 	ProblemType string `xml:"problemType"`
 	Success     bool   `xml:"success"`


### PR DESCRIPTION
Just wanted to give you a chance to look this over before I put more time into it. I still have to figure out tests. Since I'm new to Golang, it may take a while.

This batch does a big cleanup of `force push` as well as adds some more support.

Now `force push` can be used in 3 ways:

`force push classes MyClass`
`force push ApexClass MyClass`
`force push path/to/file.cls`

The first two usages will look from the working directory and into either `src` or `metadata` for the metadata type folder and then to the file. Once it finds the file, it passes the path into the new method created that takes a relative or absolute path to the file.

If you're interested in merging, I can cleanup my debug comments and do whatever other format things you think makes sense. If not, I'll just keep my fork.

Thanks for the tool!
