### PR TITLE
Reference version from force.go

### DIFF
--- a/force.go
+++ b/force.go
@@ -36,7 +36,8 @@ const (
 )
 
 const (
-	apiVersion = "v30.0" // Spring 14
+	apiVersion       = "v30.0" // Spring 14
+	apiVersionNumber = "30.0"
 )
 
 var RootCertificates = `
@@ -442,7 +443,7 @@ func (f *Force) CreateRecord(sobject string, attrs map[string]string) (id string
 }
 
 func (f *Force) CreateBulkJob(xmlbody string) (result JobInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job", f.Credentials.InstanceUrl)
+	url := fmt.Sprintf("%s/services/async/%s/job", f.Credentials.InstanceUrl, apiVersionNumber)
 	body, err := f.httpPostXML(url, xmlbody)
 	xml.Unmarshal(body, &result)
 	if len(result.Id) == 0 {
@@ -454,7 +455,7 @@ func (f *Force) CreateBulkJob(xmlbody string) (result JobInfo, err error) {
 }
 
 func (f *Force) CloseBulkJob(jobId string, xmlbody string) (result JobInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s", f.Credentials.InstanceUrl, jobId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
 	body, err := f.httpPostXML(url, xmlbody)
 	xml.Unmarshal(body, &result)
 	if len(result.Id) == 0 {
@@ -466,7 +467,7 @@ func (f *Force) CloseBulkJob(jobId string, xmlbody string) (result JobInfo, err 
 }
 
 func (f *Force) GetBulkJobs() (result []JobInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/jobs", f.Credentials.InstanceUrl)
+	url := fmt.Sprintf("%s/services/async/%s/jobs", f.Credentials.InstanceUrl, apiVersionNumber)
 	body, err := f.httpGetBulk(url)
 	xml.Unmarshal(body, &result)
 	if len(result[0].Id) == 0 {
@@ -478,7 +479,7 @@ func (f *Force) GetBulkJobs() (result []JobInfo, err error) {
 }
 
 func (f *Force) BulkQuery(soql string, jobId string, contettype string) (result BatchInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch", f.Credentials.InstanceUrl, jobId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
 	var body []byte
 
 	if contettype == "CSV" {
@@ -497,7 +498,7 @@ func (f *Force) BulkQuery(soql string, jobId string, contettype string) (result 
 }
 
 func (f *Force) AddBatchToJob(xmlbody string, jobId string) (result BatchInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch", f.Credentials.InstanceUrl, jobId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
 	body, err := f.httpPostCSV(url, xmlbody)
 	xml.Unmarshal(body, &result)
 	if len(result.Id) == 0 {
@@ -509,7 +510,7 @@ func (f *Force) AddBatchToJob(xmlbody string, jobId string) (result BatchInfo, e
 }
 
 func (f *Force) GetBatchInfo(jobId string, batchId string) (result BatchInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch/%s", f.Credentials.InstanceUrl, jobId, batchId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId)
 	body, err := f.httpGetBulk(url)
 	xml.Unmarshal(body, &result)
 	if len(result.Id) == 0 {
@@ -521,7 +522,7 @@ func (f *Force) GetBatchInfo(jobId string, batchId string) (result BatchInfo, er
 }
 
 func (f *Force) GetBatches(jobId string) (result []BatchInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch", f.Credentials.InstanceUrl, jobId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
 	body, err := f.httpGetBulk(url)
 
 	var batchInfoList struct {
@@ -539,7 +540,7 @@ func (f *Force) GetBatches(jobId string) (result []BatchInfo, err error) {
 }
 
 func (f *Force) GetJobInfo(jobId string) (result JobInfo, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s", f.Credentials.InstanceUrl, jobId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
 	body, err := f.httpGetBulk(url)
 	xml.Unmarshal(body, &result)
 	if len(result.Id) == 0 {
@@ -551,19 +552,19 @@ func (f *Force) GetJobInfo(jobId string) (result JobInfo, err error) {
 }
 
 func (f *Force) RetrieveBulkQuery(jobId string, batchId string) (result []byte, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch/%s/result", f.Credentials.InstanceUrl, jobId, batchId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s/result", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId)
 	result, err = f.httpGetBulk(url)
 	return
 }
 
 func (f *Force) RetrieveBulkQueryResults(jobId string, batchId string, resultId string) (result []byte, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch/%s/result/%s", f.Credentials.InstanceUrl, jobId, batchId, resultId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s/result/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId, resultId)
 	result, err = f.httpGetBulk(url)
 	return
 }
 
 func (f *Force) RetrieveBulkBatchResults(jobId string, batchId string) (results BatchResult, err error) {
-	url := fmt.Sprintf("%s/services/async/29.0/job/%s/batch/%s/result", f.Credentials.InstanceUrl, jobId, batchId)
+	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s/result", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId)
 	result, err := f.httpGetBulk(url)
 	if len(result) == 0 {
 		var fault LoginFault

--- a/metadata.go
+++ b/metadata.go
@@ -492,7 +492,7 @@ func (fm *ForceMetadata) ValidateFieldOptions(typ string, options map[string]str
 }
 
 func NewForceMetadata(force *Force) (fm *ForceMetadata) {
-	fm = &ForceMetadata{ApiVersion: "29.0", Force: force}
+	fm = &ForceMetadata{ApiVersion: apiVersionNumber, Force: force}
 	return
 }
 
@@ -699,7 +699,7 @@ func (fm *ForceMetadata) CheckRetrieveStatus(id string) (files ForceMetadataFile
 }
 
 func (fm *ForceMetadata) DescribeMetadata() (describe MetadataDescribeResult, err error) {
-	body, err := fm.soapExecute("describeMetadata", fmt.Sprintf("<apiVersion>%s</apiVersion>", "30.0"))
+	body, err := fm.soapExecute("describeMetadata", fmt.Sprintf("<apiVersion>%s</apiVersion>", apiVersionNumber))
 	if err != nil {
 		return
 	}
@@ -722,7 +722,7 @@ func (fm *ForceMetadata) CreateConnectedApp(name, callback string) (err error) {
 	soap := `
 		<metadata xsi:type="ConnectedApp">
 			<fullName>%s</fullName>
-			<version>29.0</version>
+			<version>%s</version>
 			<label>%s</label>
 			<contactEmail>%s</contactEmail>
 			<oauthConfig>
@@ -737,7 +737,7 @@ func (fm *ForceMetadata) CreateConnectedApp(name, callback string) (err error) {
 		return err
 	}
 	email := me["Email"]
-	body, err := fm.soapExecute("create", fmt.Sprintf(soap, name, name, email, callback))
+	body, err := fm.soapExecute("create", fmt.Sprintf(soap, name, apiVersionNumber, name, email, callback))
 	if err != nil {
 		return err
 	}
@@ -1048,7 +1048,7 @@ func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadata
 
 	soap := `
 		<retrieveRequest>
-			<apiVersion>29.0</apiVersion>
+			<apiVersion>%s</apiVersion>
 			<unpackaged>
 				%s
 			</unpackaged>
@@ -1064,7 +1064,7 @@ func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadata
 	for _, element := range query {
 		types += fmt.Sprintf(soapType, element.Name, element.Members)
 	}
-	body, err := fm.soapExecute("retrieve", fmt.Sprintf(soap, types))
+	body, err := fm.soapExecute("retrieve", fmt.Sprintf(soap, apiVersionNumber, types))
 	if err != nil {
 		return
 	}
@@ -1092,11 +1092,11 @@ func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadata
 func (fm *ForceMetadata) RetrievePackage(packageName string) (files ForceMetadataFiles, err error) {
 	soap := `
 		<retrieveRequest>
-			<apiVersion>29.0</apiVersion>
+			<apiVersion>%s</apiVersion>
 			<packageNames>%s</packageNames>
 		</retrieveRequest>
 	`
-	soap = fmt.Sprintf(soap, packageName)
+	soap = fmt.Sprintf(soap, apiVersionNumber, packageName)
 	body, err := fm.soapExecute("retrieve", soap)
 	if err != nil {
 		return
@@ -1128,7 +1128,7 @@ func (fm *ForceMetadata) ListMetadata(query string) (res []byte, err error) {
 
 func (fm *ForceMetadata) ListConnectedApps() (apps ForceConnectedApps, err error) {
 	originalVersion := fm.ApiVersion
-	fm.ApiVersion = "29.0"
+	fm.ApiVersion = apiVersionNumber
 	body, err := fm.ListMetadata("ConnectedApp")
 	fm.ApiVersion = originalVersion
 	if err != nil {


### PR DESCRIPTION
I'm not sure if there was a reason for not doing this, but I figured I'd put it out there in case you wanted to merge.

Instead of having "28.0", "29.0", "30.0" strewn around, we can
keep the version in a single file and then reference that from
elsewhere to make upgrading and changing Api versions easy

Excluded push.go because there is another patch covering that one
