### PR TITLE
switch to non-metadata API call to confirm successful login

### DIFF
--- a/login.go
+++ b/login.go
@@ -84,8 +84,16 @@ func ForceSaveLogin(creds ForceCredentials) (username string, err error) {
 	}
 	username = login["username"].(string)
 
-	describe, err := force.Metadata.DescribeMetadata()
-	creds.Namespace = describe.NamespacePrefix
+	me, err := force.Whoami()
+	if err != nil {
+		return
+	}
+	fmt.Printf("Logged in as '%s'\n", me["Username"])
+
+	describe, meta_err := force.Metadata.DescribeMetadata()
+	if meta_err != nil {
+		creds.Namespace = describe.NamespacePrefix
+	}
 
 	Config.Save("accounts", username, string(body))
 	Config.Save("current", "account", username)


### PR DESCRIPTION
Currently, after getting creds, force-cli does a metadata API call to try and get the org's package namespace (this is only helpful if the user is working directly on a managed package).  Unfortunately, there's a shortcoming in the Metadata API access control model: only users with the `ModifyAllData` perm can make metadata calls.  While that's fine for DE orgs (or developers working in sandbox orgs), it's an inappropriate permission for the vast majority of SFDC customer accounts.  But as a result of the post-login call, a normal user would get something like this...

```
tmaher@og-kush:~$ force login
ERROR: INSUFFICIENT_ACCESS: use of the Metadata API requires a user with the ModifyAllData permission
```

A user unfamiliar with the permission model could easily interpret this to mean "I should go get my org admin to give me ModifyAllData".  I would rather we not do that.  For maximum confusion, because of how `ForceSaveLogin` is structured, the SID/OAuth access token is actually saved _regardless_ of whether the metadata call succeeds.

This PR switches to doing a generic whoami to confirm successful login.  If the call fails, we don't persist the SID/token.  We still _try_ the metadata call, but don't freak out if it fails.
