### PR TITLE
Auto detect the current endpoint when logging in

### DIFF
--- a/force.go
+++ b/force.go
@@ -154,13 +154,14 @@ type Force struct {
 }
 
 type ForceCredentials struct {
-	AccessToken string
-	Id          string
-	InstanceUrl string
-	IssuedAt    string
-	Scope       string
-	IsCustomEP  bool
-	Namespace   string
+	AccessToken   string
+	Id            string
+	InstanceUrl   string
+	IssuedAt      string
+	Scope         string
+	IsCustomEP    bool
+	Namespace     string
+	ForceEndpoint ForceEndpoint
 }
 
 type LoginFault struct {
@@ -355,7 +356,7 @@ func ForceSoapLogin(endpoint ForceEndpoint, username string, password string) (c
 	}
 	instanceUrl := u.Scheme + "://" + u.Host
 	identity := u.Scheme + "://" + u.Host + "/id/" + orgid + "/" + result.Id
-	creds = ForceCredentials{result.SessionId, identity, instanceUrl, "", "", endpoint == EndpointCustom, ""}
+	creds = ForceCredentials{result.SessionId, identity, instanceUrl, "", "", endpoint == EndpointCustom, "", endpoint}
 
 	return
 }
@@ -379,6 +380,7 @@ func ForceLogin(endpoint ForceEndpoint) (creds ForceCredentials, err error) {
 
 	err = Open(url)
 	creds = <-ch
+	creds.ForceEndpoint = endpoint
 	return
 }
 


### PR DESCRIPTION
Since refresh tokens haven't been implemented yet, I felt it important
to streamline the login process. Rather than always defaulting
`force login` to production, it will instead default it to whatever the
current endpoint is.

Note that the other changes here are from the old master before history was rewritten. If you don't want them remerged, I can revert them on my master branch and resubmit this.
