### PR TITLE
temporary workaround for binaries urls - updating README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ A command-line interface to force.com
 ##### Precompiled Binaries
 If the download does not work, download instead from the [binaries](https://github.com/heroku/force/tree/master/binaries) folder in the repo.
 
-* [Linux 32bit](https://godist.herokuapp.com/projects/heroku/force/releases/current/linux-386/force)
-* [Linux 64bit](https://godist.herokuapp.com/projects/heroku/force/releases/current/linux-amd64/force)
-* [OS X 32bit](https://godist.herokuapp.com/projects/heroku/force/releases/current/darwin-386/force)
-* [OS X 64bit](https://godist.herokuapp.com/projects/heroku/force/releases/current/darwin-amd64/force)
-* [Windows 32bit](https://godist.herokuapp.com/projects/heroku/force/releases/current/windows-386/force.exe)
-* [Windows 64bit](https://godist.herokuapp.com/projects/heroku/force/releases/current/windows-amd64/force.exe)
+* [Linux 32bit](https://github.com/heroku/force/raw/master/binaries/linux-386/force)
+* [Linux 64bit](https://github.com/heroku/force/raw/master/binaries/linux-amd64/force)
+* [Linux Arm](https://github.com/heroku/force/raw/master/binaries/linux-arm/force)
+* [OS X 32bit](https://github.com/heroku/force/raw/master/binaries/darwin-386/force)
+* [OS X 64bit](https://github.com/heroku/force/raw/master/binaries/darwin-386/force)
+* [Windows 32bit](https://github.com/heroku/force/raw/master/binaries/windows-386/force.exe)
+* [Windows 64bit](https://github.com/heroku/force/raw/master/binaries/windows-amd64/force.exe)
 
 ##### Compile from Source
 

--- a/binaries/README.md
+++ b/binaries/README.md
@@ -1,13 +1,5 @@
 ## force
 
-Important information about binaries
-
-##### These binaries are not the same as the binaries in the main README.
-
-##### These binaries are not automatically created with each new release.
-
-##### The binaries on the main README ARE automatically created with each new release.
-
 ### Cross Compiling
 See the excellent work by Dave Cheney and follow his instructions carefully.
 


### PR DESCRIPTION
Updated Links in the main repository README.md file to point to the relative binary files in the binaries directory of this repository.  Also added a link to the Linux ARM binary.
Updated the binaries/README.md to remove notice about these binaries being different to the released binaries, as they currently are the same.
