### PR TITLE
Dynamically detect src dir and provide package builder

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,39 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/ddollar/config"
 )
 
 var Config = config.NewConfig("force")
+
+func GetSourceDir() (src string, err error) {
+	// Last element is default
+	var sourceDirs = []string{
+		"src",
+		"metadata",
+	}
+
+	wd, _ := os.Getwd()
+	for _, src = range sourceDirs {
+		_, err = os.Stat(filepath.Join(wd, src, "package.xml"))
+		// Found a real source dir
+		if err == nil {
+			return
+		}
+	}
+
+	return
+}
+
+func ExitIfNoSourceDir(err error) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			ErrorAndExit("Current directory does not contain a metadata or src directory")
+		}
+
+		ErrorAndExit(err.Error())
+	}
+}

--- a/error.go
+++ b/error.go
@@ -17,3 +17,9 @@ func ErrorAndExit(format string, args ...interface{}) {
 	}
 	os.Exit(1)
 }
+
+func ExitIfError(err error, format string, args ...interface{}) {
+	if err != nil {
+		ErrorAndExit(format, args)
+	}
+}

--- a/fetch.go
+++ b/fetch.go
@@ -66,8 +66,9 @@ func runFetchAura(cmd *Command, entityname string) {
 	}
 
 	var defRecords = definitions.Records
-	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "metadata", "aurabundles")
+	root, err := GetSourceDir()
+
+	root = filepath.Join(root, "aurabundles")
 
 	if err := os.MkdirAll(root, 0755); err != nil {
 		ErrorAndExit(err.Error())
@@ -111,8 +112,6 @@ func runFetchAura(cmd *Command, entityname string) {
 }
 
 func runFetch(cmd *Command, args []string) {
-	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "metadata")
 	if len(args) < 1 {
 		ErrorAndExit("must specify object type and/or object name")
 	}
@@ -164,42 +163,47 @@ func runFetch(cmd *Command, args []string) {
 	var resourcesMap map[string]string
 	resourcesMap = make(map[string]string)
 
+	root, err := GetSourceDir()
+	existingPackage, _ := pathExists(filepath.Join(root, "package.xml"))
+
 	for name, data := range files {
-		file := filepath.Join(root, name)
-		dir := filepath.Dir(file)
+		if !existingPackage || name != "package.xml" {
+			file := filepath.Join(root, name)
+			dir := filepath.Dir(file)
 
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			ErrorAndExit(err.Error())
-		}
-		if err := ioutil.WriteFile(filepath.Join(root, name), data, 0644); err != nil {
-			ErrorAndExit(err.Error())
-		}
-		var isResource = false
-		if artifactType == "StaticResource" {
-			isResource = true
-		} else if strings.HasSuffix(file, ".resource-meta.xml") {
-			isResource = true
-		}
-		//Handle expanding static resources into a "bundle" folder
-		if isResource && expandResources && name != "package.xml" {
-			pathParts := strings.Split(name, string(os.PathSeparator))
-			resourceName := pathParts[cap(pathParts)-1]
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				ErrorAndExit(err.Error())
+			}
+			if err := ioutil.WriteFile(filepath.Join(root, name), data, 0644); err != nil {
+				ErrorAndExit(err.Error())
+			}
+			var isResource = false
+			if artifactType == "StaticResource" {
+				isResource = true
+			} else if strings.HasSuffix(file, ".resource-meta.xml") {
+				isResource = true
+			}
+			//Handle expanding static resources into a "bundle" folder
+			if isResource && expandResources {
+				pathParts := strings.Split(name, string(os.PathSeparator))
+				resourceName := pathParts[cap(pathParts)-1]
 
-			resourceExt := strings.Split(resourceName, ".")[1]
-			resourceName = strings.Split(resourceName, ".")[0]
-			if resourceExt == "resource-meta" {
-				//Check the xml to determine the mime type of the resource
-				// We are looking for application/zip
-				var meta struct {
-					CacheControl string `xml:"cacheControl"`
-					ContentType  string `xml:"contentType"`
-				}
-				if err = xml.Unmarshal([]byte(data), &meta); err != nil {
-					//return
-				}
-				if meta.ContentType == "application/zip" {
-					// this is the meat for a zip file, so add the map
-					resourcesMap[resourceName] = filepath.Join(filepath.Dir(file), resourceName+".resource")
+				resourceExt := strings.Split(resourceName, ".")[1]
+				resourceName = strings.Split(resourceName, ".")[0]
+				if resourceExt == "resource-meta" {
+					//Check the xml to determine the mime type of the resource
+					// We are looking for application/zip
+					var meta struct {
+						CacheControl string `xml:"cacheControl"`
+						ContentType  string `xml:"contentType"`
+					}
+					if err = xml.Unmarshal([]byte(data), &meta); err != nil {
+						//return
+					}
+					if meta.ContentType == "application/zip" {
+						// this is the meat for a zip file, so add the map
+						resourcesMap[resourceName] = filepath.Join(filepath.Dir(file), resourceName+".resource")
+					}
 				}
 			}
 		}
@@ -252,4 +256,15 @@ func runFetch(cmd *Command, args []string) {
 	}
 
 	fmt.Printf("Exported to %s\n", root)
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }

--- a/packagebuilder.go
+++ b/packagebuilder.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Structs for XML building
+type Package struct {
+	Xmlns   string     `xml:"xmlns,attr"`
+	Types   []MetaType `xml:"types"`
+	Version string     `xml:"version"`
+}
+
+type MetaType struct {
+	Members []string `xml:"members"`
+	Name    string   `xml:"name"`
+}
+
+func createPackage() Package {
+	return Package{
+		Version: strings.TrimPrefix(apiVersion, "v"),
+		Xmlns:   "http://soap.sforce.com/2006/04/metadata",
+	}
+}
+
+type metapath struct {
+	path string
+	name string
+}
+
+var metapaths = []metapath{
+	metapath{"classes", "ApexClass"},
+	metapath{"objects", "CustomObject"},
+	metapath{"tabs", "CustomTab"},
+	metapath{"labels", "CustomLabels"},
+	metapath{"flexipages", "FlexiPage"},
+	metapath{"components", "ApexComponent"},
+	metapath{"triggers", "ApexTrigger"},
+	metapath{"pages", "ApexPage"},
+}
+
+type PackageBuilder struct {
+	IsPush   bool
+	Metadata map[string]MetaType
+	Files    ForceMetadataFiles
+}
+
+func NewPushBuilder() PackageBuilder {
+	pb := PackageBuilder{IsPush: true}
+	pb.Metadata = make(map[string]MetaType)
+	pb.Files = make(ForceMetadataFiles)
+
+	return pb
+}
+
+func NewFetchBuilder() PackageBuilder {
+	pb := PackageBuilder{IsPush: false}
+	pb.Metadata = make(map[string]MetaType)
+	pb.Files = make(ForceMetadataFiles)
+
+	return pb
+}
+
+// Build and return package.xml
+func (pb PackageBuilder) PackageXml() []byte {
+	p := createPackage()
+
+	for _, metaType := range pb.Metadata {
+		p.Types = append(p.Types, metaType)
+	}
+
+	byteXml, _ := xml.MarshalIndent(p, "", "    ")
+	byteXml = append([]byte(xml.Header), byteXml...)
+
+	return byteXml
+}
+
+// Returns the full ForceMetadataFiles container
+func (pb *PackageBuilder) ForceMetadataFiles() ForceMetadataFiles {
+	pb.Files["package.xml"] = pb.PackageXml()
+	return pb.Files
+}
+
+// Add a file to the builder
+func (pb *PackageBuilder) AddFile(fpath string) (fname string, err error) {
+	fpath, err = filepath.Abs(fpath)
+	if err != nil {
+		return
+	}
+	_, err = os.Stat(fpath)
+	if err != nil {
+		return
+	}
+
+	metaName, fname := getMetaTypeFromPath(fpath)
+	pb.AddMetaToPackage(metaName, fname)
+
+	// If it's a push, we want to actually add the files
+	if pb.IsPush {
+		err = pb.addFileToWorkingDir(fpath)
+	}
+
+	return
+}
+
+// Adds the file to a temp directory for deploy
+func (pb *PackageBuilder) addFileToWorkingDir(fpath string) (err error) {
+	// Get relative dir from source
+	srcDir := filepath.Dir(filepath.Dir(fpath))
+	frel, _ := filepath.Rel(srcDir, fpath)
+
+	// Try to find meta file
+	hasMeta := true
+	fmeta := fpath + "-meta.xml"
+	fmetarel := ""
+	if _, err = os.Stat(fmeta); err != nil {
+		if os.IsNotExist(err) {
+			hasMeta = false
+		} else {
+			// Has error
+			return
+		}
+	} else {
+		// Should be present since we worked back to srcDir
+		fmetarel, _ = filepath.Rel(srcDir, fmeta)
+	}
+
+	fdata, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return
+	}
+
+	pb.Files[frel] = fdata
+	if hasMeta {
+		fdata, err = ioutil.ReadFile(fmeta)
+		pb.Files[fmetarel] = fdata
+		return
+	}
+
+	return
+}
+
+// Adds a metadata name to the pending package
+func (pb *PackageBuilder) AddMetaToPackage(metaName string, name string) {
+	mt := pb.Metadata[metaName]
+	if mt.Name == "" {
+		mt.Name = metaName
+	}
+
+	mt.Members = append(mt.Members, name)
+
+	pb.Metadata[metaName] = mt
+}
+
+// Gets metadata type name and target name from a file path
+func getMetaTypeFromPath(fpath string) (metaName string, name string) {
+	fpath, err := filepath.Abs(fpath)
+	if err != nil {
+		ErrorAndExit("Cound not find " + fpath)
+	}
+	if _, err := os.Stat(fpath); err != nil {
+		ErrorAndExit("Cound not open " + fpath)
+	}
+
+	// Get name of file
+	name = filepath.Base(fpath)
+	name = strings.TrimSuffix(name, filepath.Ext(name))
+
+	// Get the directory containing the file
+	fdir := filepath.Dir(fpath)
+	typePath := filepath.Base(fdir)
+
+	// Get the meta type for that directory
+	metaName = getMetaForPath(typePath)
+
+	return
+}
+
+// Gets partial path based on a meta type name
+func getPathForMeta(metaname string) string {
+	for _, mp := range metapaths {
+		if strings.EqualFold(mp.name, metaname) {
+			return mp.path
+		}
+	}
+
+	// Unknown, so use metaname
+	return metaname
+}
+
+// Gets meta type name based on a partial path
+func getMetaForPath(path string) string {
+	for _, mp := range metapaths {
+		if mp.path == path {
+			return mp.name
+		}
+	}
+
+	// Unknown, so use path
+	return path
+}


### PR DESCRIPTION
A way to dynamically detect wich directory the source exists in as well
as a builder that will easily build packages for use with push and
fetch. Greatly cleans up the push.go file and could be used with
fetch.go with some work
