### PR TITLE
Issues with sObject and field creations

### DIFF
--- a/display.go
+++ b/display.go
@@ -435,8 +435,8 @@ func DisplayFieldTypes() {
   richtextarea           (length = 32768, visibleLines = 5)
   checkbox/bool/boolean  (defaultValue = false)
   datetime               ()
-  float/double/currency  (length = 16, precision = 2)
-  number/int             (length = 18, precision = 0)
+  float/double/currency  (precision = 16, scale = 2)
+  number/int             (precision = 18, scale = 0)
   autonumber             (displayFormat = "AN {00000}", startingNumber = 0)
   geolocation            (displayLocationInDecimal = true, scale = 5)
   lookup                 (will be prompted for Object and label)
@@ -605,10 +605,9 @@ func DisplayDoubleFieldDetails() (message string) {
 
     %s
       label            - defaults to name
-      length           - defaults to 18
       name
-      precision        - decimal places (defaults to 0)
-      scale            - digits left of decimal (defaults to 18)
+      precision        - digits left of decimal (defaults to 18)
+      scale            - decimal places (defaults to 0)
   
     %s
       description
@@ -627,10 +626,9 @@ func DisplayCurrencyFieldDetails() (message string) {
 
     %s
       label            - defaults to name
-      length           - defaults to 18
       name
-      precision        - decimal places (defaults to 0)
-      scale            - digits left of decimal (defaults to 18)
+      precision        - digits left of decimal (defaults to 18)
+      scale            - decimal places (defaults to 0)
   
     %s
       description

--- a/metadata.go
+++ b/metadata.go
@@ -152,7 +152,6 @@ type FloatFieldRequired struct {
 }
 
 type FloatField struct {
-	Length               int    `xml:"length"`
 	Description          string `xml:"description"`
 	HelpText             string `xml:"helpText"`
 	Unique               bool   `xml:"unique"`
@@ -170,7 +169,6 @@ type NumberFieldRequired struct {
 }
 
 type NumberField struct {
-	Length               int    `xml:"length"`
 	Description          string `xml:"description"`
 	HelpText             string `xml:"helpText"`
 	Unique               bool   `xml:"unique"`
@@ -178,6 +176,8 @@ type NumberField struct {
 	DefaultValue         uint   `xml:"defaultValue"`
 	Formula              string `xml:"formula"`
 	FormulaTreatBlanksAs string `xml:"formulaTreatBlanksAs"`
+	Precision            int    `xml:"precision"`
+	Scale                int    `xml:"scale"`
 }
 
 type DatetimeFieldRequired struct {
@@ -361,7 +361,6 @@ func getAttributes(m interface{}) map[string]reflect.StructField {
 
 func ValidateOptionsAndDefaults(typ string, fields map[string]reflect.StructField, requiredDefaults reflect.Value, options map[string]string) (newOptions map[string]string, err error) {
 	newOptions = make(map[string]string)
-
 	// validate optional attributes
 	for name, value := range options {
 		field, ok := fields[strings.ToLower(name)]

--- a/sobject.go
+++ b/sobject.go
@@ -21,11 +21,12 @@ Usage:
 
   force sobject list
 
-  force sobject create <object> [<field>:<type>]...
+  force sobject create <object> [<field>:<type> [<option>:<value>]] 
 
   force sobject delete <object>
 
   force sobject import
+  
 Examples:
 
   force sobject list
@@ -85,20 +86,12 @@ func runSobjectCreate(args []string) {
 	if err := force.Metadata.CreateCustomObject(args[0]); err != nil {
 		ErrorAndExit(err.Error())
 	}
-	for _, field := range args[1:] {
-		parts := strings.Split(field, ":")
-		if len(parts) != 2 {
-			ErrorAndExit("must specify name:type for fields")
-		} else {
-			if err := force.Metadata.CreateCustomField(fmt.Sprintf("%s__c", args[0]), parts[0], parts[1], nil); err != nil {
-				ErrorAndExit(err.Error())
-			}
-		}
-	}
-	args[0] = fmt.Sprintf("%s__c", args[0])
-
-	runFieldCreate(args)
 	fmt.Println("Custom object created")
+
+	if len(args) > 1 {
+		args[0] = fmt.Sprintf("%s__c", args[0])
+		runFieldCreate(args)
+	}
 }
 
 func runSobjectDelete(args []string) {


### PR DESCRIPTION
# sObject creation

Fixed issue about always trying to add field when creating an sObject
even if no field was defined on cmd-line. The fields where also
attempted to be created twice. No field options where respected.
# Custom Field creation

The NumberField struc did not contain all the fields and this stopped
creation of these fields. Numeric and float field does not support a
length attribute (API restriction). Member was removed from structs.

Display text where corrected. Length removed and description of Precision
and Scale seemed to have been swapped.
