### PR TITLE
Fix InAuraBundlesFolder function always return false on Widnows.

### DIFF
--- a/pushAura.go
+++ b/pushAura.go
@@ -271,9 +271,9 @@ func getDefinitionFormat(deftype string) (result string) {
 func InAuraBundlesFolder(fname string) bool {
 	info, _ := os.Stat(fname)
 	if info.IsDir() {
-		return strings.HasSuffix(filepath.Dir(fname), "metadata/aura")
+		return strings.HasSuffix(filepath.Dir(fname), filepath.FromSlash("metadata/aura"))
 	} else {
-		return strings.HasSuffix(filepath.Dir(filepath.Dir(fname)), "metadata/aura")
+		return strings.HasSuffix(filepath.Dir(filepath.Dir(fname)), filepath.FromSlash("metadata/aura"))
 	}
 }
 


### PR DESCRIPTION
On Windows, filepath.Dir(fname) returns "path\to\dir" and it never matches slash separated path.

filepath.FromSlash will replace slashes to os-dependent separator.
http://golang.org/pkg/path/filepath/#FromSlash
