### PR TITLE
Limited the display to classes that present 1% or more Code Coverage

### DIFF
--- a/test.go
+++ b/test.go
@@ -60,16 +60,17 @@ func runTests(cmd *Command, args []string) {
 		fmt.Println(output.Log)
 		fmt.Println()
 	}
-	var percent string
+	var percent int
 	fmt.Println("Coverage:")
 	fmt.Println()
 	for index := range output.NumberLocations {
 		if output.NumberLocations[index] != 0 {
-			percent = strconv.Itoa(((output.NumberLocations[index]-output.NumberLocationsNotCovered[index])/output.NumberLocations[index])*100) + "%"
-		} else {
-			percent = "0%"
+			percent = ((output.NumberLocations[index] - output.NumberLocationsNotCovered[index]) / output.NumberLocations[index]) * 100
 		}
-		fmt.Println("  " + percent + "   " + output.Name[index])
+
+		if percent > 0 {
+			fmt.Println("   " + strconv.Itoa(percent) + "%   " + output.Name[index])
+		}
 	}
 	fmt.Println()
 	fmt.Println()

--- a/test_test.go
+++ b/test_test.go
@@ -43,6 +43,22 @@ var _ = Describe("Test", func() {
 			_, err := RunTests(stub, []string{"Fail"}, "")
 			Expect(err).ToNot(HaveOccurred())
 		})
+
 	})
 
+	Describe("generateResults", func() {
+		var (
+			results = TestCoverage{
+				NumberRun: 5,
+				NumberFailures: 2,
+				NumberLocations: []int {1,1,1,1,1},
+				NumberLocationsNotCovered: []int {0,0,1,0,1},
+				Name: []string {"Test1", "Test2", "Test3", "Test4", "Test5"}}
+		)
+
+		It("should ignore test classes with 0% coverage", func() {
+			output := GenerateResults(results)
+			Expect(output).ToNot(MatchRegexp(`\D0%`))
+		})
+	})
 })

--- a/test_test.go
+++ b/test_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Test", func() {
 	Describe("generateResults", func() {
 		var (
 			results = TestCoverage{
-				NumberRun: 5,
-				NumberFailures: 2,
-				NumberLocations: []int {1,1,1,1,1},
-				NumberLocationsNotCovered: []int {0,0,1,0,1},
-				Name: []string {"Test1", "Test2", "Test3", "Test4", "Test5"}}
+				NumberRun:                 5,
+				NumberFailures:            2,
+				NumberLocations:           []int{1, 1, 1, 1, 1},
+				NumberLocationsNotCovered: []int{0, 0, 1, 0, 1},
+				Name: []string{"Test1", "Test2", "Test3", "Test4", "Test5"}}
 		)
 
 		It("should ignore test classes with 0% coverage", func() {


### PR DESCRIPTION
Changes made to the test sub-command in order to suppress the display of code coverage for classes in which it is less than 1.

Talked about in Issue #259.

Did not include a flag to display the complete code coverage because saw no point of it. If you need a list of all classes in the instance test is not the command to get it.

Also had to change the type of the percent variable so I could use it in the conditional in line 71.

Please review; suggestions are welcome.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/heroku/force/267)

<!-- Reviewable:end -->
