### PR TITLE
Initial Scratch Org Creation Support

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -13,9 +13,9 @@ import (
 
 var cmdLogin = &Command{
 	Usage: "login",
-	Short: "force login [-i=<instance>] [<-u=username> <-p=password>]",
+	Short: "force login [-i=<instance>] [<-u=username> <-p=password>] [-scratch]",
 	Long: `
-  force login [-i=<instance>] [<-u=username> <-p=password> <-v=apiversion]
+  force login [-i=<instance>] [<-u=username> <-p=password> <-v=apiversion] [-scratch]
 
   Examples:
     force login
@@ -25,6 +25,7 @@ var cmdLogin = &Command{
     force login -i=na1-blitz01.soma.salesforce.com -u=un -p=pw -v 39.0
     force login -i my-domain.my.salesforce.com -u username -p password
     force login --connected-app-client-id <my-consumer-key> -u username -key jwt.key
+    force login -scratch
 `,
 }
 
@@ -41,9 +42,17 @@ var (
 	api_version          = cmdLogin.Flag.String("v", "", "API Version to use")
 	connectedAppClientId = cmdLogin.Flag.String("connected-app-client-id", "", "Client Id (aka Consumer Key) to use instead of default")
 	keyFile              = cmdLogin.Flag.String("key", "", "JWT Signing Key Filename")
+	scratchOrg           = cmdLogin.Flag.Bool("scratch", false, "Create new Scratch Org and Log In")
 )
 
 func runLogin(cmd *Command, args []string) {
+	if *scratchOrg {
+		_, err := ForceScratchLoginAndSave(os.Stderr)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		return
+	}
 	endpoint := "https://login.salesforce.com"
 	// If no instance specified, try to get last endpoint used
 	if *instance == "" {

--- a/lib/auth.go
+++ b/lib/auth.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -103,6 +104,26 @@ func ForceLoginAtEndpointAndSaveSoap(endpoint string, user_name string, password
 	}
 
 	username, err = ForceSaveLogin(creds, output)
+	return
+}
+
+// Create a new scratch org, login, and make it active
+func ForceScratchLoginAndSave(output *os.File) (username string, err error) {
+	force, err := ActiveForce()
+	if err != nil {
+		err = errors.New("You must be logged into a Dev Hub org to authenticate as a scratch org user.")
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Creating new Scratch Org...")
+	scratchOrgId, err := force.CreateScratchOrg()
+	if err != nil {
+		return
+	}
+	session, err := force.ForceLoginNewScratch(scratchOrgId)
+	if err != nil {
+		return
+	}
+	username, err = ForceSaveLogin(session, output)
 	return
 }
 

--- a/lib/force.go
+++ b/lib/force.go
@@ -31,6 +31,7 @@ var SessionExpiredError = errors.New("Session expired")
 var APILimitExceededError = errors.New("API limit exceeded")
 var ClassNotFoundError = errors.New("class not found")
 var MetricsNotFoundError = errors.New("metrics not found")
+var DevHubOrgRequiredError = errors.New("Org must be a Dev Hub")
 
 const (
 	EndpointProduction = iota

--- a/lib/scratch.go
+++ b/lib/scratch.go
@@ -16,6 +16,11 @@ type ScratchOrg struct {
 	AuthCode    string
 }
 
+type AuthCodeSession struct {
+	ForceSession
+	RefreshToken string `json:"refresh_token"`
+}
+
 func (s *ScratchOrg) tokenURL() string {
 	return fmt.Sprintf("%s/services/oauth2/token", s.InstanceUrl)
 }
@@ -48,6 +53,7 @@ func (f *Force) ForceLoginNewScratch(scratchOrgId string) (session ForceSession,
 		RefreshMethod: RefreshOauth,
 	}
 	session.ForceEndpoint = EndpointTest
+	session.ClientId = "SalesforceDevelopmentExperience"
 	return
 }
 
@@ -84,9 +90,17 @@ func (s *ScratchOrg) getSession() (session ForceSession, err error) {
 	if err != nil {
 		return
 	}
+	var authSession AuthCodeSession
 
-	json.Unmarshal(body, &session)
-	return
+	err = json.Unmarshal(body, &authSession)
+	if err != nil {
+		return
+	}
+
+	session = authSession.ForceSession
+	session.RefreshToken = authSession.RefreshToken
+
+	return session, nil
 }
 
 // Create a new Scratch Org from a Dev Hub Org

--- a/lib/scratch.go
+++ b/lib/scratch.go
@@ -1,0 +1,106 @@
+package lib
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+)
+
+type ScratchOrg struct {
+	UserName    string
+	InstanceUrl string
+	AuthCode    string
+}
+
+func (s *ScratchOrg) tokenURL() string {
+	return fmt.Sprintf("%s/services/oauth2/token", s.InstanceUrl)
+}
+
+func (f *Force) getScratchOrg(scratchOrgId string) (scratchOrg ScratchOrg, err error) {
+	org, err := f.GetRecord("ScratchOrgInfo", scratchOrgId)
+	if err != nil {
+		err = errors.New("Unable to query scratch orgs.  You must be logged into a Dev Hub org.")
+		return
+	}
+	scratchOrg = ScratchOrg{
+		UserName:    org["SignupUsername"].(string),
+		InstanceUrl: fmt.Sprintf("https://%s.salesforce.com", org["SignupInstance"].(string)),
+		AuthCode:    org["AuthCode"].(string),
+	}
+	return
+}
+
+// Log into a Scratch Org
+func (f *Force) ForceLoginNewScratch(scratchOrgId string) (session ForceSession, err error) {
+	scratchOrg, err := f.getScratchOrg(scratchOrgId)
+	if err != nil {
+		return
+	}
+	session, err = scratchOrg.getSession()
+	if err != nil {
+		return
+	}
+	session.SessionOptions = &SessionOptions{
+		RefreshMethod: RefreshOauth,
+	}
+	session.ForceEndpoint = EndpointTest
+	return
+}
+
+// Use the AuthCode for a new Scratch Org from the Dev Hub to get a new
+// ForceSession
+func (s *ScratchOrg) getSession() (session ForceSession, err error) {
+	attrs := url.Values{}
+	attrs.Set("grant_type", "authorization_code")
+	attrs.Set("code", s.AuthCode)
+	attrs.Set("client_id", "SalesforceDevelopmentExperience")
+	attrs.Set("client_secret", "1384510088588713504")
+	attrs.Set("redirect_uri", "http://localhost:1717/OauthRedirect")
+
+	postVars := attrs.Encode()
+	req, err := httpRequest("POST", s.tokenURL(), bytes.NewReader([]byte(postVars)))
+	if err != nil {
+		return
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	fmt.Fprintln(os.Stderr, "Logging into scratch org")
+	res, err := doRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if res.StatusCode != 200 {
+		var oauthError OAuthError
+		json.Unmarshal(body, &oauthError)
+		err = errors.New("Unable to log into scratch org: " + oauthError.ErrorDescription)
+		return
+	}
+	if err != nil {
+		return
+	}
+
+	json.Unmarshal(body, &session)
+	return
+}
+
+// Create a new Scratch Org from a Dev Hub Org
+func (f *Force) CreateScratchOrg() (id string, err error) {
+	params := make(map[string]string)
+	params["ConnectedAppCallbackUrl"] = "http://localhost:1717/OauthRedirect"
+	params["ConnectedAppConsumerKey"] = "SalesforceDevelopmentExperience"
+	params["Country"] = "US"
+	params["Edition"] = "Developer"
+	params["Features"] = "AuthorApex;API;AddCustomApps:30;AddCustomTabs:30;ForceComPlatform;Sites;CustomerSelfService"
+	params["OrgName"] = "Force CLI Scratch"
+	id, err, _ = f.CreateRecord("ScratchOrgInfo", params)
+	if err != nil {
+		return
+	}
+	return
+}

--- a/lib/scratch.go
+++ b/lib/scratch.go
@@ -98,8 +98,11 @@ func (f *Force) CreateScratchOrg() (id string, err error) {
 	params["Edition"] = "Developer"
 	params["Features"] = "AuthorApex;API;AddCustomApps:30;AddCustomTabs:30;ForceComPlatform;Sites;CustomerSelfService"
 	params["OrgName"] = "Force CLI Scratch"
-	id, err, _ = f.CreateRecord("ScratchOrgInfo", params)
+	id, err, messages := f.CreateRecord("ScratchOrgInfo", params)
 	if err != nil {
+		if len(messages) == 1 && messages[0].ErrorCode == "NOT_FOUND" {
+			return "", DevHubOrgRequiredError
+		}
 		return
 	}
 	return


### PR DESCRIPTION
Initial support for creating a new scratch org and logging into it
(without using sfdx cli).

`force login -scratch` creates a new scratch org using the active
session, which must be a Dev Hub org.  The user is logged into the new
scratch org and the session is saved so the session token can be
refreshed using OAuth rather than using the sfdx cli like `force
usedxauth`.

The scratch org features are currently hard-coded, and setting org
preferences like `sfdx force:org:create` is not supported yet.