### PR TITLE
Update Repo Organization to ForceCLI

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -124,18 +124,18 @@
 						<div class="button-toolbar button-toolbar-centered flush-bottom download-buttons">
 
 							<div class="button button-primary inverse" id="button-download-osx">
-								<a href="/releases/v0.22.79/darwin-amd64/force" style="color:#58488a;">	Download for Mac OS X
+								<a href="/releases/v0.22.84/darwin-amd64/force" style="color:#58488a;">	Download for Mac OS X
 								</a>
 							</div>
 
 							<div class="button button-primary inverse hide" id="button-download-windows">
-								<a href="/releases/v0.22.79/windows-amd64/force.exe" style="color:#58488a;">	Download for Windows
+								<a href="/releases/v0.22.84/windows-amd64/force.exe" style="color:#58488a;">	Download for Windows
 								</a>
 							</div>
 
 
 							<div class="button button-primary inverse hide" id="button-download-debian-ubuntu">
-								<a href="/releases/v0.22.79/linux-amd64/force" style="color:#58488a;">	Download for Debian/Ubuntu
+								<a href="/releases/v0.22.84/linux-amd64/force" style="color:#58488a;">	Download for Debian/Ubuntu
 								</a>
 							</div>
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,11 +21,12 @@ http {
 		listen ${{PORT}};
 
 		location /releases/ {
-			rewrite /releases/([^/]+)/([^/]+)-([^/]+)/force(\.exe)?$ /heroku/force/releases/download/$1/force_$2_$3$4 break;
+			rewrite /releases/([^/]+)/([^/]+)-([^/]+)/force(\.exe)?$ /ForceCLI/force/releases/download/$1/force_$2_$3$4 break;
 			proxy_pass https://github.com/;
 			proxy_http_version 1.1;
 			proxy_intercept_errors on;
 			error_page 301 302 307 = @handle_redirect;
+			recursive_error_pages on;
 		}
 
 		location @handle_redirect {
@@ -34,6 +35,9 @@ http {
 			proxy_pass $saved_redirect_location;
 			proxy_buffering off;
 			proxy_hide_header Content-Disposition;
+			proxy_intercept_errors on;
+			error_page 301 302 307 = @handle_redirect;
+			recursive_error_pages on;
 		}
 	}
 }


### PR DESCRIPTION
Change name of github organization from heroku to ForceCLI.

Update nginx proxy configuration to handle multiple redirects.

Update latest version to 0.22.84.