### PR TITLE
Fix Serial Concurrency Mode

### DIFF
--- a/command/bulk.go
+++ b/command/bulk.go
@@ -565,7 +565,7 @@ func createBulkJob(objectType string, operation string, fileFormat string, exter
 	}
 
 	if strings.EqualFold(concurrencyMode, "serial") {
-		job.ConcurrencyMode = "serial"
+		job.ConcurrencyMode = "Serial"
 	}
 
 	if operation == "upsert" {

--- a/lib/bulk.go
+++ b/lib/bulk.go
@@ -29,8 +29,8 @@ type JobInfo struct {
 	CreatedDate             string   `xml:"createdDate,omitempty"`
 	SystemModStamp          string   `xml:"systemModstamp,omitempty"`
 	State                   string   `xml:"state,omitempty"`
-	ContentType             string   `xml:"contentType,omitempty"`
 	ConcurrencyMode         string   `xml:"concurrencyMode,omitempty"`
+	ContentType             string   `xml:"contentType,omitempty"`
 	NumberBatchesQueued     int      `xml:"numberBatchesQueued,omitempty"`
 	NumberBatchesInProgress int      `xml:"numberBatchesInProgress,omitempty"`
 	NumberBatchesCompleted  int      `xml:"numberBatchesCompleted,omitempty"`


### PR DESCRIPTION
Fix Serial concurrency mode when using `force bulk`.  In order for the
jobInfo XML to be accepted:
- the value of the concurrencyMode element, Serial, must be capitalized
- the concurrencyMode element must be before the contentType element