### PR TITLE
Complete the work to add 'upsert' to the positional arguments version of the `force bulk` command.

### DIFF
--- a/command/bulk.go
+++ b/command/bulk.go
@@ -220,7 +220,7 @@ func runBulk(cmd *Command, args []string) {
 	switch command {
 	case "query":
 		handleQuery(args)
-	case "insert", "update", "delete":
+	case "insert", "update", "upsert", "delete":
 		handleDML(args)
 	case "batch", "batches", "job":
 		handleInfo(args)


### PR DESCRIPTION
I had started this back in March (https://github.com/ForceCLI/force/commits?author=slancio) but according to https://github.com/ForceCLI/force/issues/453 I left this work incomplete.  This commit resolves that error.