### PR TITLE
Use New Fork of config Library

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/devangel/config"
+	"github.com/ForceCLI/config"
 )
 
 var Config = config.NewConfig("force")


### PR DESCRIPTION
Use new fork of config library that uses the homedir library to find the
user's home directory, which should be more robust on Windows.