### PR TITLE
Travis Build Clean-Up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,11 @@ script:
 - export GO_LINKER_VALUE=$(git describe --tags --always)
 - export GO_LINKER_SYMBOL="github.com/ForceCLI/force/lib.Version"
 - gox -os "$OS_TARGETS" -arch="$ARCH_TARGETS" -ldflags "-X $GO_LINKER_SYMBOL=$GO_LINKER_VALUE"
-- mkdir -p darwin/amd64 && cp force_darwin_amd64 darwin/amd64/force
-- mkdir -p darwin/386 && cp force_darwin_386 darwin/386/force
-- mkdir -p windows/amd64 && cp force_windows_amd64.exe windows/amd64/force.exe
-- mkdir -p windows/386 && cp force_windows_386.exe windows/386/force.exe
-- mkdir -p linux/amd64 && cp force_linux_amd64 linux/amd64/force
-- mkdir -p linux/386 && cp force_linux_386 linux/386/force
 deploy:
 - provider: releases
   skip_cleanup: true
   api_key:
-    secure: W+4pJY7DjLNMU91i3LAOqr6FV+PUnoqCoY1kM9IZ391MCot6EAHkYAdlhSJ2+qllIWmamp7Dtv7Ul4AAfhnAbKJY+J2w5/HczctvjGvcER/QIiWgPfZaNkAqBcWu8XXjdJ876J6sfzWVudK/onnPgpKvtVX0WRZEBXgUl0QJp2g=
+    secure: ZKXOj+6IJmEhv8r9QDY50BPvXj9lawJ/4URPavYPRoOH66xJvUeEPw6Weor2qx30z6dh6Eu2VME9rVx9q4+fb5erhuNYckL1qnaIO/z8k3bQuM0aBvcYB+BX6kdHKJcQHKrg12+Otj5aWlx3SXRENIAILhAOz43I75uryMTqN3o=
   file:
     - force_darwin_amd64
     - force_darwin_386


### PR DESCRIPTION
Delete commands to rename binaries, previously used for S3 releases.

Replace dcarroll's GitHub token with cwarden's so new releases don't
impersonate the former.