### PR TITLE
Stream CSV and JSON Query Results

### DIFF
--- a/command/datapipe.go
+++ b/command/datapipe.go
@@ -144,7 +144,7 @@ func runDataPipelineListJobs() {
 		ErrorAndExit(err.Error())
 	}
 
-	DisplayForceRecordsf(result.Records, "csv")
+	force.DisplayAllForceRecordsf(result, "csv")
 }
 
 func runDataPipelineQueryJob() {
@@ -156,7 +156,7 @@ func runDataPipelineQueryJob() {
 		ErrorAndExit(err.Error())
 	}
 
-	DisplayForceRecordsf(result.Records, "csv")
+	force.DisplayAllForceRecordsf(result, "csv")
 }
 
 func runDataPipelineQuery() {
@@ -272,5 +272,5 @@ func runDataPipelineList() {
 		ErrorAndExit(err.Error())
 	}
 
-	DisplayForceRecordsf(result.Records, format)
+	force.DisplayAllForceRecordsf(result, format)
 }

--- a/command/trace.go
+++ b/command/trace.go
@@ -57,7 +57,7 @@ func runQueryTrace() {
 	if err != nil {
 		ErrorAndExit(err.Error())
 	}
-	DisplayForceRecordsf(result.Records, "json-pretty")
+	force.DisplayAllForceRecordsf(result, "json-pretty")
 }
 
 func runStartTrace(userId ...string) {


### PR DESCRIPTION
Write csv- and json-formatted query results to stdout as they are
received rather than waiting for all results to be retrieved.

Fixes out-of-memory errors when querying large result sets.

Note that all results are still retrieved when writing to stdout in the
default format because the column widths need to be calculated from the
results.

Update Force.QueryAndSend to accept optional QueryOptions parameters to
support queryAll and tooling options.