### PR TITLE
Fix Output of Records Asynchronously

### DIFF
--- a/command/query.go
+++ b/command/query.go
@@ -94,12 +94,13 @@ func runQuery(cmd *Command, args []string) {
 			DisplayForceRecords(records)
 		} else {
 			records := make(chan ForceRecord)
-			go DisplayForceRecordsf(records, queryOutputFormat)
+			done := make(chan bool)
+			go DisplayForceRecordsf(records, queryOutputFormat, done)
 			err := force.QueryAndSend(fmt.Sprintf("%s", soql), records, queryOptions...)
 			if err != nil {
 				ErrorAndExit(err.Error())
 			}
-
+			<-done
 		}
 	}
 }


### PR DESCRIPTION
Wait for DisplayForceRecordsf goroutine to finish before exiting when
output is being generated incrementally.