### PR TITLE
Allow Custom Client Id When Logging In

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -34,9 +34,10 @@ var (
 	instance = cmdLogin.Flag.String("i", "", `Defaults to 'login' or last
 		logged in system. non-production server to login to (values are 'pre',
 		'test', or full instance url`)
-	userName    = cmdLogin.Flag.String("u", "", "Username for Soap Login")
-	password    = cmdLogin.Flag.String("p", "", "Password for Soap Login")
-	api_version = cmdLogin.Flag.String("v", "", "API Version to use")
+	userName             = cmdLogin.Flag.String("u", "", "Username for Soap Login")
+	password             = cmdLogin.Flag.String("p", "", "Password for Soap Login")
+	api_version          = cmdLogin.Flag.String("v", "", "API Version to use")
+	connectedAppClientId = cmdLogin.Flag.String("connected-app-client-id", "", "Client Id (aka Consumer Key) to use instead of default")
 )
 
 func runLogin(cmd *Command, args []string) {
@@ -55,6 +56,10 @@ func runLogin(cmd *Command, args []string) {
 	if *api_version != "" {
 		// Todo verify format of version is 30.0
 		SetApiVersion(*api_version)
+	}
+
+	if *connectedAppClientId != "" {
+		ClientId = *connectedAppClientId
 	}
 
 	switch *instance {

--- a/command/oauth.go
+++ b/command/oauth.go
@@ -20,7 +20,7 @@ Usage:
 
 Examples:
 
-  force oauth create MyApp https://myapp.herokuapp.com/auth/callback
+  force oauth create MyApp http://localhost:3835/oauth/callback
 `,
 }
 

--- a/lib/force.go
+++ b/lib/force.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/ForceCLI/force/error"
 )
 
-const (
+var (
 	ClientId    = "3MVG9ytVT1SanXDnX_hOa9Ys5NxVp5C26JlyQjwr.xTJtUqoKonXY.M8CcjoEknMrV4YUvPvXLiMyzI.Aw23C"
 	RedirectUri = "http://localhost:3835/oauth/callback"
 )
@@ -71,6 +71,7 @@ type ForceSession struct {
 	InstanceUrl    string `json:"instance_url"`
 	IssuedAt       string `json:"issued_at"`
 	Scope          string `json:"scope"`
+	ClientId       string
 	RefreshToken   string
 	ForceEndpoint  ForceEndpoint
 	UserInfo       *UserInfo
@@ -326,6 +327,7 @@ func ForceLogin(endpoint ForceEndpoint) (creds ForceSession, err error) {
 		}
 	}
 	creds.ForceEndpoint = endpoint
+	creds.ClientId = ClientId
 	return
 }
 

--- a/lib/session.go
+++ b/lib/session.go
@@ -16,6 +16,9 @@ func (f *Force) refreshOauth() (err error) {
 	attrs.Set("grant_type", "refresh_token")
 	attrs.Set("refresh_token", f.Credentials.RefreshToken)
 	attrs.Set("client_id", ClientId)
+	if f.Credentials.ClientId != "" {
+		attrs.Set("client_id", f.Credentials.ClientId)
+	}
 	attrs.Set("format", "json")
 
 	postVars := attrs.Encode()


### PR DESCRIPTION
Allow a custom client id to be used when logging.  Store the client id
with the session info, and use it when refreshing the OAuth token.