### PR TITLE
Report Problems Retrieving Metadata

### DIFF
--- a/command/fetch.go
+++ b/command/fetch.go
@@ -234,6 +234,7 @@ func runFetch(cmd *Command, args []string) {
 	}
 
 	var files ForceMetadataFiles
+	var problems []string
 	var err error
 	var expandResources bool = unpack
 
@@ -248,7 +249,7 @@ func runFetch(cmd *Command, args []string) {
 	} else if len(metadataTypes) == 1 && strings.ToLower(metadataTypes[0]) == "package" {
 		if len(metadataName) > 0 {
 			for names := range metadataName {
-				files, err = force.Metadata.RetrievePackage(metadataName[names])
+				files, problems, err = force.Metadata.RetrievePackage(metadataName[names])
 				if err != nil {
 					ErrorAndExit(err.Error())
 				}
@@ -259,7 +260,7 @@ func runFetch(cmd *Command, args []string) {
 		}
 	} else {
 		if len(packageXml) > 0 {
-			files, err = force.Metadata.RetrieveByPackageXml(packageXml)
+			files, problems, err = force.Metadata.RetrieveByPackageXml(packageXml)
 		} else {
 			query := ForceMetadataQuery{}
 			if len(metadataName) > 0 {
@@ -271,7 +272,7 @@ func runFetch(cmd *Command, args []string) {
 					ErrorAndExit(err.Error())
 				}
 			}
-			files, err = force.Metadata.Retrieve(query)
+			files, problems, err = force.Metadata.Retrieve(query)
 			if err != nil {
 				ErrorAndExit(err.Error())
 			}
@@ -291,6 +292,9 @@ func runFetch(cmd *Command, args []string) {
 	}
 	existingPackage, _ := pathExists(filepath.Join(root, "package.xml"))
 
+	for _, problem := range problems {
+		fmt.Fprintln(os.Stderr, problem)
+	}
 	if len(files) == 1 {
 		ErrorAndExit("Could not find any objects for " + strings.Join(metadataTypes, ", ") + ". (Is the metadata type correct?)")
 	}

--- a/command/security.go
+++ b/command/security.go
@@ -265,9 +265,12 @@ func runSecurity(cmd *Command, args []string) {
 	force, _ := ActiveForce()
 
 	// Step 1: retrieve the desired metadata
-	files, err := force.Metadata.Retrieve(query)
+	files, problems, err := force.Metadata.Retrieve(query)
 	if err != nil {
 		ErrorAndExit(err.Error())
+	}
+	for _, problem := range problems {
+		fmt.Fprintln(os.Stderr, problem)
 	}
 
 	// Step 2: go through the metadata and construct a list of Profile (profiles) and a CustomObject (theObject)

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -725,14 +725,15 @@ func (fm *ForceMetadata) CheckDeployStatus(id string) (results ForceCheckDeploym
 	return
 }
 
-func (fm *ForceMetadata) CheckRetrieveStatus(id string) (files ForceMetadataFiles, err error) {
+func (fm *ForceMetadata) CheckRetrieveStatus(id string) (files ForceMetadataFiles, problems []string, err error) {
 	body, err := fm.soapExecute("checkRetrieveStatus", fmt.Sprintf("<id>%s</id>", id))
 	if err != nil {
 		fmt.Printf("Hrm... will probably try again\n")
 		return
 	}
 	var status struct {
-		ZipFile string `xml:"Body>checkRetrieveStatusResponse>result>zipFile"`
+		ZipFile  string   `xml:"Body>checkRetrieveStatusResponse>result>zipFile"`
+		Problems []string `xml:"Body>checkRetrieveStatusResponse>result>messages>problem"`
 	}
 	if err = xml.Unmarshal(body, &status); err != nil {
 		return
@@ -741,6 +742,7 @@ func (fm *ForceMetadata) CheckRetrieveStatus(id string) (files ForceMetadataFile
 	if err != nil {
 		return
 	}
+	problems = status.Problems
 
 	zipfiles, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if preserveZip == true {
@@ -1239,7 +1241,7 @@ func (fm *ForceMetadata) DeployZipFile(soap string, zipfile []byte) (results For
 	return
 }
 
-func (fm *ForceMetadata) RetrieveByPackageXml(package_xml string) (files ForceMetadataFiles, err error) {
+func (fm *ForceMetadata) RetrieveByPackageXml(package_xml string) (files ForceMetadataFiles, problems []string, err error) {
 	// Need to crack open the xml file and pull out the <types> array
 	data, err := ioutil.ReadFile(package_xml)
 
@@ -1292,7 +1294,7 @@ func (fm *ForceMetadata) RetrieveByPackageXml(package_xml string) (files ForceMe
 		fmt.Printf("Error: %s\n", err.Error())
 		return
 	}
-	raw_files, err := fm.CheckRetrieveStatus(status.Id)
+	raw_files, problems, err := fm.CheckRetrieveStatus(status.Id)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
 		return
@@ -1306,7 +1308,7 @@ func (fm *ForceMetadata) RetrieveByPackageXml(package_xml string) (files ForceMe
 	return
 }
 
-func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadataFiles, err error) {
+func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadataFiles, problems []string, err error) {
 
 	soap := `
 		<retrieveRequest>
@@ -1347,7 +1349,7 @@ func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadata
 	if err = fm.CheckStatus(status.Id); err != nil {
 		return
 	}
-	raw_files, err := fm.CheckRetrieveStatus(status.Id)
+	raw_files, problems, err := fm.CheckRetrieveStatus(status.Id)
 	if err != nil {
 		return
 	}
@@ -1359,7 +1361,7 @@ func (fm *ForceMetadata) Retrieve(query ForceMetadataQuery) (files ForceMetadata
 	return
 }
 
-func (fm *ForceMetadata) RetrievePackage(packageName string) (files ForceMetadataFiles, err error) {
+func (fm *ForceMetadata) RetrievePackage(packageName string) (files ForceMetadataFiles, problems []string, err error) {
 	soap := `
 		<retrieveRequest>
 			<apiVersion>%s</apiVersion>
@@ -1380,7 +1382,7 @@ func (fm *ForceMetadata) RetrievePackage(packageName string) (files ForceMetadat
 	if err = fm.CheckStatus(status.Id); err != nil {
 		return
 	}
-	raw_files, err := fm.CheckRetrieveStatus(status.Id)
+	raw_files, problems, err := fm.CheckRetrieveStatus(status.Id)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Display problems when retrieving metadata, for example, when the named
metadata object does not exist or is not valid in the org.

Make display of problems optional for `force export`.