### PR TITLE
Fix Forced Logout for Old, Invalid Session

### DIFF
--- a/lib/auth.go
+++ b/lib/auth.go
@@ -180,7 +180,8 @@ func GetAccountCredentials(accountName string) (creds ForceSession, err error) {
 	err = upgradeCredentials(&creds)
 	if err != nil {
 		// Couldn't update the credentials.  Force re-login.
-		err = Config.Delete("current", "account")
+		_ = Config.Delete("accounts", accountName)
+		_ = Config.DeleteLocalOrGlobal("current", "account")
 		ErrorAndExit("Cannot update stored session.  Please log in again.")
 	}
 	if creds.SessionOptions.ApiVersion != "" && creds.SessionOptions.ApiVersion != ApiVersionNumber() {


### PR DESCRIPTION
Fix bug in which login can fail when switching between versions of force
cli.  An error occurs if:
- you have used `force active -l`
- you have authenticated with a version prior to v0.22.79
- your session has expired