### PR TITLE
Enable push command to read filenames from pipe

### DIFF
--- a/command/export.go
+++ b/command/export.go
@@ -105,6 +105,7 @@ func runExport(cmd *Command, args []string) {
 		{Name: []string{"EntitlementTemplate"}, Members: []string{"*"}},
 		{Name: []string{"ExternalDataSource"}, Members: []string{"*"}},
 		{Name: []string{"FieldSet"}, Members: []string{"*"}},
+		{Name: []string{"FlexiPage"}, Members: []string{"*"}},
 		{Name: []string{"Flow"}, Members: []string{"*"}},
 		{Name: []string{"FlowDefinition"}, Members: []string{"*"}},
 		{Name: []string{"Folder"}, Members: []string{"*"}},

--- a/command/export.go
+++ b/command/export.go
@@ -86,6 +86,7 @@ func runExport(cmd *Command, args []string) {
 		{Name: []string{"Community"}, Members: []string{"*"}},
 		{Name: []string{"CompactLayout"}, Members: []string{"*"}},
 		{Name: []string{"ConnectedApp"}, Members: []string{"*"}},
+		{Name: []string{"ContentAsset"}, Members: []string{"*"}},
 		{Name: []string{"ContractSettings"}, Members: []string{"*"}},
 		{Name: []string{"CustomApplication"}, Members: []string{"*"}},
 		{Name: []string{"CustomApplicationComponent"}, Members: []string{"*"}},

--- a/command/push.go
+++ b/command/push.go
@@ -2,10 +2,12 @@ package command
 
 import (
 	"archive/zip"
+	"bufio"
 	"bytes"
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,7 +24,8 @@ var cmdPush = &Command{
 	Short: "Deploy artifact from a local directory",
 	Long: `
 Deploy artifact from a local directory 
-<metadata>: Accepts either actual directory name or Metadata type
+<metadata>: Accepts either actual directory name or Metadata type, 
+Command can read filenames from pipe (result of previously executed command followed by '|'), see examples
 
 Examples:
   force push -t StaticResource -n MyResource
@@ -30,6 +33,7 @@ Examples:
   force push -f metadata/classes/MyClass.cls
   force push -checkonly -test MyClass_Test metadata/classes/MyClass.cls
   force push -n MyApex -n MyObject__c
+  git diff HEAD~1 --name-only --diff-filter=ACM | force push
 
 Deployment Options
   -rollbackonerror, -r    Indicates whether any failure causes a complete rollback
@@ -93,18 +97,23 @@ func runPush(cmd *Command, args []string) {
 		// way than if it's a file.
 		validatePushByMetadataTypeCommand()
 		PushByPaths(resourcepaths, false, namePaths, deployOpts())
-	} else {
-		if len(metadataName) > 0 {
-			if len(metadataType) != 0 {
-				validatePushByMetadataTypeCommand()
-				pushByMetadataType()
-			} else {
-				ErrorAndExit("The -type (-t) parameter is required.")
+	} else if len(metadataType) != 0 {
+		validatePushByMetadataTypeCommand()
+		pushByMetadataType()
+	} else { //trying to read from pipe
+		reader := bufio.NewReader(os.Stdin)
+		for {
+			filePath, err := reader.ReadString('\n')
+			if err != nil && err == io.EOF {
+				break
 			}
-		} else {
-			validatePushByMetadataTypeCommand()
-			pushByMetadataType()
+			resourcepaths = append(resourcepaths, strings.TrimSuffix(filePath, "\n"))
 		}
+		if len(resourcepaths) < 1 {
+			ErrorAndExit("Nothing to push. Please spefify metadata-components you want to deploy")
+		}
+		validatePushByMetadataTypeCommand()
+		PushByPaths(resourcepaths, false, namePaths, deployOpts())
 	}
 }
 

--- a/command/push.go
+++ b/command/push.go
@@ -33,7 +33,7 @@ Examples:
   force push -f metadata/classes/MyClass.cls
   force push -checkonly -test MyClass_Test metadata/classes/MyClass.cls
   force push -n MyApex -n MyObject__c
-  git diff HEAD~1 --name-only --diff-filter=ACM | force push
+  git diff HEAD~1 --name-only --diff-filter=ACM | force push -f -
 
 Deployment Options
   -rollbackonerror, -r    Indicates whether any failure causes a complete rollback
@@ -91,7 +91,26 @@ func runPush(cmd *Command, args []string) {
 	}
 	// Treat trailing args as file paths
 	resourcepaths = append(resourcepaths, args...)
+
+	if len(metadataType) == 0 && len(resourcepaths) < 1 {
+		ErrorAndExit("Nothing to push. Please spefify metadata-components you want to deploy")
+	}
+
 	if len(resourcepaths) > 0 {
+		if len(resourcepaths) == 1 && resourcepaths[0] == "-" {
+			resourcepaths = resourcepaths[1:]
+			reader := bufio.NewReader(os.Stdin)
+			for {
+				filePath, err := reader.ReadString('\n')
+				if err != nil && err == io.EOF {
+					break
+				}
+				resourcepaths = append(resourcepaths, strings.TrimSuffix(filePath, "\n"))
+			}
+			if len(resourcepaths) < 1 {
+				ErrorAndExit("Nothing to push. Please spefify metadata-components you want to deploy")
+			}
+		}
 		// It's not a package but does have a path. This could be a path to a file
 		// or to a folder. If it is a folder, we pickup the resources a different
 		// way than if it's a file.
@@ -100,20 +119,6 @@ func runPush(cmd *Command, args []string) {
 	} else if len(metadataType) != 0 {
 		validatePushByMetadataTypeCommand()
 		pushByMetadataType()
-	} else { //trying to read from pipe
-		reader := bufio.NewReader(os.Stdin)
-		for {
-			filePath, err := reader.ReadString('\n')
-			if err != nil && err == io.EOF {
-				break
-			}
-			resourcepaths = append(resourcepaths, strings.TrimSuffix(filePath, "\n"))
-		}
-		if len(resourcepaths) < 1 {
-			ErrorAndExit("Nothing to push. Please spefify metadata-components you want to deploy")
-		}
-		validatePushByMetadataTypeCommand()
-		PushByPaths(resourcepaths, false, namePaths, deployOpts())
 	}
 }
 

--- a/lib/packagebuilder.go
+++ b/lib/packagebuilder.go
@@ -86,6 +86,7 @@ var metapaths = []metapath{
 	metapath{path: "matchingRules", name: "MatchingRules"},
 	metapath{path: "matchingRules", name: "MatchingRule"},
 	metapath{path: "namedCredentials", name: "NamedCredential"},
+	metapath{path: "networks", name: "Network"},
 	metapath{path: "objects", name: "CustomObject"},
 	metapath{path: "objectTranslations", name: "CustomObjectTranslation"},
 	metapath{path: "pages", name: "ApexPage"},

--- a/lib/packagebuilder.go
+++ b/lib/packagebuilder.go
@@ -56,6 +56,7 @@ var metapaths = []metapath{
 	metapath{path: "communities", name: "Community"},
 	metapath{path: "components", name: "ApexComponent"},
 	metapath{path: "connectedApps", name: "ConnectedApp"},
+	metapath{path: "contentassets", name: "ContentAsset"},
 	metapath{path: "corsWhitelistOrigins", name: "CorsWhitelistOrigin"},
 	metapath{path: "customApplicationComponents", name: "CustomApplicationComponent"},
 	metapath{path: "customMetadata", name: "CustomMetadata"},


### PR DESCRIPTION
Enable pipe for push command so you can use the following command line
`git diff HEAD --name-only --diff-filter=ACM | force push`

It will allow you to push files that were modified since the last commit.