### PR TITLE
Set proper metadata name for files in networks folder

### DIFF
--- a/lib/packagebuilder.go
+++ b/lib/packagebuilder.go
@@ -86,6 +86,7 @@ var metapaths = []metapath{
 	metapath{path: "matchingRules", name: "MatchingRules"},
 	metapath{path: "matchingRules", name: "MatchingRule"},
 	metapath{path: "namedCredentials", name: "NamedCredential"},
+	metapath{path: "networks", name: "Network"},
 	metapath{path: "objects", name: "CustomObject"},
 	metapath{path: "objectTranslations", name: "CustomObjectTranslation"},
 	metapath{path: "pages", name: "ApexPage"},


### PR DESCRIPTION
There was impossible to push files from src/networks folder. 
This is a fix for network metadata files
