### PR TITLE
Add Option to Activate Remote Site Settings When Installing Packages

### DIFF
--- a/command/package.go
+++ b/command/package.go
@@ -16,8 +16,20 @@ Manage installed packages
 
 Usage:
 
-  force package install <namespace> <version> [password]
+  force package [options] install <namespace> <version> [password]
+
+Options:
+  -activate, -a     Keep the isActive state of any Remote Site Settings (RSS) and Content Security Policies (CSP) in package
 `,
+}
+
+var (
+	activateRSS bool
+)
+
+func init() {
+	cmdPackage.Flag.BoolVar(&activateRSS, "a", false, "keep the isActive state of any Remote Site Settings (RSS) and Content Security Policies (CSP) in package")
+	cmdPackage.Flag.BoolVar(&activateRSS, "activate", false, "keep the isActive state of any Remote Site Settings (RSS) and Content Security Policies (CSP) in package")
 }
 
 func runPackage(cmd *Command, args []string) {
@@ -44,7 +56,7 @@ func runInstallPackage(args []string) {
 	if len(args) > 2 {
 		password = args[2]
 	}
-	if err := force.Metadata.InstallPackage(packageNamespace, version, password); err != nil {
+	if err := force.Metadata.InstallPackageWithRSS(packageNamespace, version, password, activateRSS); err != nil {
 		ErrorAndExit(err.Error())
 	}
 	fmt.Println("Package instaled")

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -1104,14 +1104,20 @@ func (fm *ForceMetadata) CreateBigObject(object BigObject) (err error) {
 }
 
 func (fm *ForceMetadata) InstallPackage(namespace, version, password string) (err error) {
+	activateRemoteSiteSettings := false
+	return fm.InstallPackageWithRSS(namespace, version, password, activateRemoteSiteSettings)
+}
+
+func (fm *ForceMetadata) InstallPackageWithRSS(namespace, version, password string, activateRemoteSiteSettings bool) (err error) {
 	soap := `
 		<metadata xsi:type="InstalledPackage" xmlns:cmd="http://soap.sforce.com/2006/04/metadata">
 			<fullName>%s</fullName>
 			<versionNumber>%s</versionNumber>
 			<password>%s</password>
+			<activateRSS>%t</activateRSS>
 		</metadata>
 	`
-	body, err := fm.soapExecute("create", fmt.Sprintf(soap, namespace, version, password))
+	body, err := fm.soapExecute("create", fmt.Sprintf(soap, namespace, version, password, activateRemoteSiteSettings))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add activate flag to `force package install` to allow Remote Site
Settings and Content Security Policies included in the package to be
activated during installation.