### PR TITLE
Add Support for PK Chunking

### DIFF
--- a/command/bulk.go
+++ b/command/bulk.go
@@ -57,6 +57,7 @@ import (
 	"encoding/csv"
 	"encoding/xml"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -107,6 +108,7 @@ Examples using positional arguments - less flexible, arguments must be in the co
   force Bulk batch [job id] [batch id]
   force bulk batch retrieve [job id] [batch id]
   force bulk [-wait | -w] query Account [SOQL]
+  force bulk [-chunk | -p]=50000 query Account [SOQL]
   force bulk query retrieve [job id] [batch id]
 
 `,
@@ -120,6 +122,7 @@ var (
 	fileFormat        string
 	externalId        string
 	concurrencyMode   string
+	pkChunkSize       int
 	waitForCompletion bool
 )
 var commandVersion = "old"
@@ -141,6 +144,8 @@ func init() {
 	cmdBulk.Flag.StringVar(&concurrencyMode, "concurrencyMode", "Parallel", "Concurrency mode for bulk api inserts, updates, deletes and upserts.  Valid options are `Serial` and `Parallel` (default).")
 	cmdBulk.Flag.BoolVar(&waitForCompletion, "wait", false, "Wait for job to complete")
 	cmdBulk.Flag.BoolVar(&waitForCompletion, "w", false, "Wait for job to complete")
+	cmdBulk.Flag.IntVar(&pkChunkSize, "chunk", 0, "PK chunk size")
+	cmdBulk.Flag.IntVar(&pkChunkSize, "p", 0, "PK chunk size")
 	cmdBulk.Run = runBulk
 }
 
@@ -177,7 +182,7 @@ func runBulkInfoCommand() {
 		if command == "retrieve" {
 			fmt.Println(string(getBulkQueryResults(jobId, batchId)))
 		} else /* batch or status */ {
-			DisplayBatchInfo(getBatchDetails(jobId, batchId))
+			DisplayBatchInfo(getBatchDetails(jobId, batchId), os.Stdout)
 		}
 	default:
 		ErrorAndExit("Unknown sub-command " + command + ".")
@@ -297,7 +302,7 @@ func setConcurrencyModeOrFileFormat(argument string) {
 	}
 }
 
-func doBulkQuery(objectType string, soql string, contenttype string, concurrencyMode string) {
+func startBulkQuery(objectType string, soql string, contenttype string, concurrencyMode string) (jobInfo JobInfo, batchId string) {
 	jobInfo, err := createBulkJob(objectType, "query", contenttype, "", concurrencyMode)
 	if err != nil {
 		ErrorAndExit(err.Error())
@@ -305,12 +310,34 @@ func doBulkQuery(objectType string, soql string, contenttype string, concurrency
 	force, _ := ActiveForce()
 
 	result, err := force.BulkQuery(soql, jobInfo.Id, contenttype)
-	batchId := result.Id
+	batchId = result.Id
 	if err != nil {
 		closeBulkJob(jobInfo.Id)
 		ErrorAndExit(err.Error())
 	}
+	// Wait for chunking to complete
+	if pkChunkSize > 0 {
+		for {
+			batchInfo, err := force.GetBatchInfo(jobInfo.Id, batchId)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to get bulk batch status: %s\n", err.Error())
+				os.Exit(1)
+			}
+			DisplayBatchInfo(batchInfo, os.Stderr)
+			if batchInfo.State == "NotProcessed" {
+				// batches have been created
+				break
+			}
+			time.Sleep(2000 * time.Millisecond)
+		}
+	}
+
 	closeBulkJob(jobInfo.Id)
+	return
+}
+
+func doBulkQuery(objectType string, soql string, contenttype string, concurrencyMode string) {
+	jobInfo, batchId := startBulkQuery(objectType, soql, contenttype, concurrencyMode)
 	if !waitForCompletion {
 		fmt.Println("Query Submitted")
 		if commandVersion == "new" {
@@ -322,10 +349,11 @@ func doBulkQuery(objectType string, soql string, contenttype string, concurrency
 		}
 		return
 	}
+	force, _ := ActiveForce()
 	for {
 		status, err := force.GetJobInfo(jobInfo.Id)
 		if err != nil {
-			fmt.Println("Failed to get bulk job status: " + err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to get bulk job status: %s\n", err.Error())
 			os.Exit(1)
 		}
 		DisplayJobInfo(status, os.Stderr)
@@ -334,22 +362,46 @@ func doBulkQuery(objectType string, soql string, contenttype string, concurrency
 		}
 		time.Sleep(2000 * time.Millisecond)
 	}
-	fmt.Println(string(getBulkQueryResults(jobInfo.Id, batchId)))
+	// Each result set in each batch will contain the header row.  Display
+	// the header only once, for the first result set of the first (non-empty)
+	// batch.
+	headerDisplayed := false
+	for _, batchInfo := range getBatches(jobInfo.Id) {
+		if batchInfo.State == "Failed" {
+			fmt.Fprintf(os.Stderr, "Batch failed: %s\n", batchInfo.StateMessage)
+			os.Exit(1)
+		}
+		results := getBulkQueryResults(jobInfo.Id, batchInfo.Id)
+		if len(results) == 0 {
+			continue
+		}
+		if headerDisplayed && strings.ToUpper(contenttype) == "CSV" {
+			results = stripFirstLine(results)
+		}
+		headerDisplayed = true
+		fmt.Print(string(results))
+	}
+}
+
+func stripFirstLine(data []byte) []byte {
+	newLineAt := bytes.IndexByte(data, '\n')
+	var returnFrom int
+	if newLineAt < 0 {
+		returnFrom = len(data)
+	} else {
+		returnFrom = newLineAt + 1
+	}
+	return data[returnFrom:]
 }
 
 func getBulkQueryResults(jobId string, batchId string) (data []byte) {
 	resultIds := retrieveBulkQuery(jobId, batchId)
-	hasMultipleResultFiles := len(resultIds) > 1
 
-	for _, resultId := range resultIds {
-		//since this is going to stdOut, simply add header to separate "files"
-		//if it's all in the same file, don't print this separator.
-		if hasMultipleResultFiles {
-			resultHeader := fmt.Sprint("ResultId: ", resultId, "\n")
-			data = append(data[:], []byte(resultHeader)...)
-		}
-		//get next file, and append
+	for row, resultId := range resultIds {
 		var newData []byte = retrieveBulkQueryResults(jobId, batchId, resultId)
+		if row > 0 {
+			newData = stripFirstLine(newData)
+		}
 		data = append(data[:], newData...)
 	}
 
@@ -579,7 +631,14 @@ func createBulkJob(objectType string, operation string, fileFormat string, exter
 		job.ExternalIdFieldName = externalId
 	}
 
-	jobInfo, err = force.CreateBulkJob(job)
+	var options []func(*http.Request)
+	if pkChunkSize != 0 {
+		options = append(options, func(req *http.Request) {
+			req.Header.Add("Sforce-Enable-PKChunking", fmt.Sprintf("chunkSize=%d", pkChunkSize))
+		})
+	}
+
+	jobInfo, err = force.CreateBulkJob(job, options...)
 	return
 }
 

--- a/lib/display.go
+++ b/lib/display.go
@@ -82,17 +82,15 @@ func DisplayMetadataListJson(metadataObjects []DescribeMetadataObject) {
 }
 
 func DisplayBatchList(batchInfos []BatchInfo) {
-
 	for i, batchInfo := range batchInfos {
 		fmt.Printf("Batch %d", i)
-		DisplayBatchInfo(batchInfo)
+		DisplayBatchInfo(batchInfo, os.Stdout)
 		fmt.Println()
 	}
 }
 
-func DisplayBatchInfo(batchInfo BatchInfo) {
-
-	fmt.Printf(BatchInfoTemplate, batchInfo.Id, batchInfo.JobId, batchInfo.State,
+func DisplayBatchInfo(batchInfo BatchInfo, w io.Writer) {
+	fmt.Fprintf(w, BatchInfoTemplate, batchInfo.Id, batchInfo.JobId, batchInfo.State,
 		batchInfo.CreatedDate, batchInfo.SystemModstamp,
 		batchInfo.NumberRecordsProcessed)
 }

--- a/lib/force.go
+++ b/lib/force.go
@@ -1383,29 +1383,29 @@ func (f *Force) httpGetRequest(url string, headers map[string]string) (body []by
 	return
 }
 
-func (f *Force) httpPostCSV(url string, data string) (body []byte, err error) {
-	body, err = f.httpPostWithContentType(url, data, "text/csv")
+func (f *Force) httpPostCSV(url string, data string, requestOptions ...func(*http.Request)) (body []byte, err error) {
+	body, err = f.httpPostWithContentType(url, data, "text/csv", requestOptions...)
 	if err == SessionExpiredError {
 		f.RefreshSessionOrExit()
-		return f.httpPostCSV(url, data)
+		return f.httpPostCSV(url, data, requestOptions...)
 	}
 	return
 }
 
-func (f *Force) httpPostXML(url string, data string) (body []byte, err error) {
-	body, err = f.httpPostWithContentType(url, data, "application/xml")
+func (f *Force) httpPostXML(url string, data string, requestOptions ...func(*http.Request)) (body []byte, err error) {
+	body, err = f.httpPostWithContentType(url, data, "application/xml", requestOptions...)
 	if err == SessionExpiredError {
 		f.RefreshSessionOrExit()
-		return f.httpPostXML(url, data)
+		return f.httpPostXML(url, data, requestOptions...)
 	}
 	return
 }
 
-func (f *Force) httpPostJSON(url string, data string) (body []byte, err error) {
-	body, err = f.httpPostWithContentType(url, data, "application/json")
+func (f *Force) httpPostJSON(url string, data string, requestOptions ...func(*http.Request)) (body []byte, err error) {
+	body, err = f.httpPostWithContentType(url, data, "application/json", requestOptions...)
 	if err == SessionExpiredError {
 		f.RefreshSessionOrExit()
-		return f.httpPostJSON(url, data)
+		return f.httpPostJSON(url, data, requestOptions...)
 	}
 	return
 }
@@ -1424,16 +1424,20 @@ func (f *Force) httpPatchWithContentType(url string, data string, contenttype st
 	return
 }
 
-func (f *Force) httpPostWithContentType(url string, data string, contenttype string) (body []byte, err error) {
-	body, err = f.httpPostPatchWithContentType(url, data, contenttype, "POST")
+func (f *Force) httpPostWithContentType(url string, data string, contenttype string, requestOptions ...func(*http.Request)) (body []byte, err error) {
+	body, err = f.httpPostPatchWithContentType(url, data, contenttype, "POST", requestOptions...)
 	return
 }
 
-func (f *Force) httpPostPatchWithContentType(url string, data string, contenttype string, method string) (body []byte, err error) {
+func (f *Force) httpPostPatchWithContentType(url string, data string, contenttype string, method string, requestOptions ...func(*http.Request)) (body []byte, err error) {
 	rbody := data
 	req, err := httpRequest(strings.ToUpper(method), url, bytes.NewReader([]byte(rbody)))
 	if err != nil {
 		return
+	}
+
+	for _, option := range requestOptions {
+		option(req)
 	}
 
 	req.Header.Add("X-SFDC-Session", f.Credentials.AccessToken)


### PR DESCRIPTION
Add option to `force bulk query` to enable PK Chunking.  When a value
greater than zero is set, the query will be split up into batches of
chunk size.

For CSV output, only print the header row once.  Remove the ResultId
from the output when there are more than one result sets per batch.