### PR TITLE
Removed terminal title

### DIFF
--- a/lib/auth.go
+++ b/lib/auth.go
@@ -63,8 +63,6 @@ func ForceSaveLogin(creds ForceSession, output *os.File) (sessionName string, er
 	creds.SessionOptions.ApiVersion = ApiVersionNumber()
 
 	fmt.Fprintf(output, "Logged in as '%s' (API %s)\n", creds.UserInfo.UserName, ApiVersionNumber())
-	title := fmt.Sprintf("\033];%s\007", creds.UserInfo.UserName)
-	fmt.Fprintf(output, title)
 
 	if err = SaveLogin(creds); err != nil {
 		return


### PR DESCRIPTION
This feature is not supported in Windows cmd or PowerShell. Let's remove it as it just outputs the title in console.

```
force usedxauth sandbox
Looking for sandbox in DX orgs...
Getting auth for user@test.com.sandbox (sandbox)...
Getting SFDX AUTH FOR user@test.com.sandbox
Logged in as 'user@test.com.sandbox' (API 44.0)
];user@test.com.sandboxNow using DX credentials for user@test.com.sandbox (sandbox)
```
Last line should not have this:
`];user@test.com.sandbox`