### PR TITLE
#541 added code to handle changes in aura files for values from pipe

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -105,9 +105,7 @@ func runPush(cmd *Command, args []string) {
 		resourcepaths = make(metaName, 0)
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
-			inputPathToFile := scanner.Text()
-			inputPathToFile = checkIfAuraFileAndGetBundlePath(inputPathToFile) //replace aura file reference with full bundle folder
-			resourcepaths = append(resourcepaths, inputPathToFile)
+			resourcepaths = append(resourcepaths, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
 			ErrorAndExit("Error reading stdin")
@@ -122,6 +120,14 @@ func runPush(cmd *Command, args []string) {
 		// It's not a package but does have a path. This could be a path to a file
 		// or to a folder. If it is a folder, we pickup the resources a different
 		// way than if it's a file.
+		
+		//replace aura file reference with full bundle folder
+		resorucepathsToPush := make(metaName, 0) 
+		for _, fsPath := range resourcepaths {
+			resorucepathsToPush = append(resorucepathsToPush, checkIfAuraFileAndGetBundlePath(fsPath)) 
+		}
+		resourcepaths = resorucepathsToPush
+
 		validatePushByMetadataTypeCommand()
 		PushByPaths(resourcepaths, false, namePaths, deployOpts())
 	} else {

--- a/command/push.go
+++ b/command/push.go
@@ -83,7 +83,17 @@ func init() {
 	cmdPush.Run = runPush
 }
 
+func checkIfAuraFileAndGetBundlePath(inputPathToFile string) string {
+	dirPart, filePart := filepath.Split(inputPathToFile)
+	dirPart = filepath.Dir(dirPart)
+	if strings.Contains(dirPart, "aura") && filepath.Ext(filePart) != "" && filepath.Base(filepath.Dir(dirPart)) == "aura" {
+		inputPathToFile = dirPart
+	}
+	return inputPathToFile
+}
+
 func runPush(cmd *Command, args []string) {
+
 	if strings.ToLower(metadataType) == "package" {
 		pushPackage()
 		return
@@ -95,7 +105,9 @@ func runPush(cmd *Command, args []string) {
 		resourcepaths = make(metaName, 0)
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
-			resourcepaths = append(resourcepaths, scanner.Text())
+			inputPathToFile := scanner.Text()
+			inputPathToFile = checkIfAuraFileAndGetBundlePath(inputPathToFile) //replace aura file reference with full bundle folder
+			resourcepaths = append(resourcepaths, inputPathToFile)
 		}
 		if err := scanner.Err(); err != nil {
 			ErrorAndExit("Error reading stdin")


### PR DESCRIPTION
This is a workaround for the cases when a single file from AuraDefinitionBundle is changed. force push -f - throw the following exception in such cases 

`Main markup cannot be empty. If you are trying to delete the Lightning definition bundle, directly delete the bundle instead`

What it basically do is replace path to aura single file with aura bundle folder