### PR TITLE
Display The Deploy Error Message When Import Fails

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -196,7 +196,7 @@ func runImport(cmd *Command, args []string) {
 	} else if len(testFailures) > 0 {
 		err = errors.New("Some tests failed")
 	} else if !result.Success {
-		err = errors.New(fmt.Sprintf("Status: %s", result.Status))
+		err = errors.New(fmt.Sprintf("Status: %s, Status Code: %s, Error Message: %s", result.Status, result.ErrorStatusCode, result.ErrorMessage))
 	}
 	if err != nil {
 		ErrorAndExit(err.Error())

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -157,6 +157,8 @@ type ForceCheckDeploymentStatusResult struct {
 	Details                  ComponentDetails `xml:"details"`
 	Done                     bool             `xml:"done"`
 	Id                       string           `xml:"id"`
+	ErrorMessage             string           `xml:"errorMessage"`
+	ErrorStatusCode          string           `xml:"errorStatusCode"`
 	NumberComponentErrors    int              `xml:"numberComponentErrors"`
 	NumberComponentsDeployed int              `xml:"numberComponentsDeployed"`
 	NumberComponentsTotal    int              `xml:"numberComponentsTotal"`


### PR DESCRIPTION
Display the errorStatusCode and errorMessage when a deployment fails
using `force import`.