### PR TITLE
Add exclude option to export command

### DIFF
--- a/command/export.go
+++ b/command/export.go
@@ -22,12 +22,15 @@ Export metadata to a local directory
 
 Export Options
   -w, -warnings  # Display warnings about metadata that cannot be retrieved
+  -x, -exclude   # Exclude given metadata type
 
 Examples:
 
   force export
 
   force export org/schema
+
+  force export -x ApexClass -x CustomObject
 `,
 }
 
@@ -200,7 +203,7 @@ func runExport(cmd *Command, args []string) {
 			err = fmt.Errorf("Could not get metadata in folders: %s", err.Error())
 			ErrorAndExit(err.Error())
 		}
-		
+
 		if !isExcluded(string(foldersType)) {
 			query = append(query, ForceMetadataQueryElement{Name: []string{string(foldersType)}, Members: members})
 		}

--- a/command/export_test.go
+++ b/command/export_test.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"testing"
+)
+
+func TestIsExcluded(t *testing.T) {
+	excluded := []string{"ApexClass", "CustomThing"}
+	excludeMetadataNames = append(excludeMetadataNames, excluded...)
+
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"custom", false},
+		{"CustomThing", true},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.input, func(t *testing.T) {
+			got := isExcluded(test.input)
+
+			if got != test.expected {
+				t.Errorf("Expected %v got %v for %s entry", test.expected, got, test.input)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This patch adds a new switch -x (-exclude) to `force export` fo filter out metadata types.