### PR TITLE
Refactor Logging Within lib Module

### DIFF
--- a/command/fetch.go
+++ b/command/fetch.go
@@ -267,6 +267,9 @@ func runFetch(cmd *Command, args []string) {
 	} else {
 		if len(packageXml) > 0 {
 			files, problems, err = force.Metadata.RetrieveByPackageXml(packageXml)
+			if err != nil {
+				ErrorAndExit(err.Error())
+			}
 		} else {
 			query := ForceMetadataQuery{}
 			if len(metadataName) > 0 {

--- a/lib/auth.go
+++ b/lib/auth.go
@@ -28,7 +28,7 @@ func getUserInfo(creds ForceSession) (userinfo UserInfo, err error) {
 	}
 	me, err := force.GetRecord("User", userinfo.UserId)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Problem getting user data, continuing...")
+		Log.Info("Problem getting user data, continuing...")
 		err = nil
 	}
 	userinfo.ProfileId = fmt.Sprintf("%s", me["ProfileId"])
@@ -37,7 +37,7 @@ func getUserInfo(creds ForceSession) (userinfo UserInfo, err error) {
 	if err == nil {
 		userinfo.OrgNamespace = namespace
 	} else {
-		fmt.Fprintf(os.Stderr, "Your profile does not have Modify All Data enabled. Functionallity will be limited.\n")
+		Log.Info("Your profile does not have Modify All Data enabled. Functionallity will be limited.")
 		err = nil
 	}
 	return
@@ -62,7 +62,7 @@ func ForceSaveLogin(creds ForceSession, output *os.File) (sessionName string, er
 	creds.UserInfo = &userinfo
 	creds.SessionOptions.ApiVersion = ApiVersionNumber()
 
-	fmt.Fprintf(output, "Logged in as '%s' (API %s)\n", creds.UserInfo.UserName, ApiVersionNumber())
+	Log.Info(fmt.Sprintf("Logged in as '%s' (API %s)\n", creds.UserInfo.UserName, ApiVersionNumber()))
 
 	if err = SaveLogin(creds); err != nil {
 		return

--- a/lib/deploy.go
+++ b/lib/deploy.go
@@ -21,7 +21,7 @@ func PushByPaths(fpaths []string, byName bool, namePaths map[string]string, opts
 
 		fi, err := os.Stat(fpath)
 		if err != nil {
-			fmt.Println(err)
+			Log.Info(err.Error())
 			badPaths = append(badPaths, fpath)
 			continue
 		}
@@ -31,7 +31,7 @@ func PushByPaths(fpaths []string, byName bool, namePaths map[string]string, opts
 		if mode.IsDir() {
 			dirNamePaths, dirBadPath, err := pb.AddDirectory(fpath)
 			if err != nil {
-				fmt.Println(err.Error())
+				Log.Info(err.Error())
 				badPaths = append(badPaths, dirBadPath...)
 			} else {
 				for dirContentName, dirContentPath := range dirNamePaths {
@@ -41,7 +41,7 @@ func PushByPaths(fpaths []string, byName bool, namePaths map[string]string, opts
 		} else if mode.IsRegular() { // single file processing
 			name, err := pb.AddFile(fpath)
 			if err != nil {
-				fmt.Println(err.Error())
+				Log.Info(err.Error())
 				badPaths = append(badPaths, fpath)
 			} else {
 				// Store paths by name for error messages
@@ -51,11 +51,11 @@ func PushByPaths(fpaths []string, byName bool, namePaths map[string]string, opts
 	}
 
 	if len(badPaths) == 0 {
-		fmt.Println("Deploying now...")
+		Log.Info("Deploying now...")
 		t0 := time.Now()
 		deployFiles(pb.ForceMetadataFiles(), byName, namePaths, opts)
 		t1 := time.Now()
-		fmt.Printf("The deployment took %v to run.\n", t1.Sub(t0))
+		Log.Info(fmt.Sprintf("The deployment took %v to run.\n", t1.Sub(t0)))
 	} else {
 		ErrorAndExit("Could not add the following files:\n {%v}", strings.Join(badPaths, "\n"))
 	}

--- a/lib/force.go
+++ b/lib/force.go
@@ -363,7 +363,7 @@ func (f *Force) GetCodeCoverage(classId string, className string) (err error) {
 
 	//var result ForceSobjectsResult
 	json.Unmarshal(body, &result)
-	fmt.Printf("\n%d lines covered\n%d lines not covered\n", int(result.Records[0]["NumLinesCovered"].(float64)), int(result.Records[0]["NumLinesUncovered"].(float64)))
+	Log.Info(fmt.Sprintf("\n%d lines covered\n%d lines not covered\n", int(result.Records[0]["NumLinesCovered"].(float64)), int(result.Records[0]["NumLinesUncovered"].(float64))))
 	return
 }
 

--- a/lib/log.go
+++ b/lib/log.go
@@ -1,0 +1,22 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+)
+
+type Logger interface {
+	Info(...interface{})
+}
+
+var Log Logger
+
+func init() {
+	Log = defaultLogger{}
+}
+
+type defaultLogger struct{}
+
+func (l defaultLogger) Info(args ...interface{}) {
+	fmt.Fprintln(os.Stderr, args...)
+}

--- a/lib/session.go
+++ b/lib/session.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	. "github.com/ForceCLI/force/error"
 	"io/ioutil"
 	"net/url"
-	"os"
 )
 
 func (f *Force) refreshOauth() (err error) {
@@ -27,10 +25,9 @@ func (f *Force) refreshOauth() (err error) {
 		return
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	fmt.Fprintln(os.Stderr, "Refreshing Session Token")
+	Log.Info("Refreshing Session Token")
 	res, err := doRequest(req)
 	if err != nil {
-		fmt.Println(err.Error())
 		return
 	}
 	defer res.Body.Close()
@@ -50,7 +47,7 @@ func (f *Force) refreshOauth() (err error) {
 }
 
 func (f *Force) refreshSFDX() (err error) {
-	fmt.Fprintln(os.Stderr, "Refreshing Session Token Using SFDX")
+	Log.Info("Refreshing Session Token Using SFDX")
 	sfdxAuth, err := GetSFDXAuth(f.Credentials.UserInfo.UserName)
 	if err != nil {
 		return

--- a/lib/sfdx.go
+++ b/lib/sfdx.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"encoding/json"
-	"fmt"
 	. "github.com/ForceCLI/force/error"
 	"os"
 	"os/exec"
@@ -41,7 +40,7 @@ func UseSFDXSession(authData SFDXAuth) {
 }
 
 func GetSFDXAuth(user string) (auth SFDXAuth, err error) {
-	fmt.Println("Getting SFDX AUTH FOR " + user)
+	Log.Info("Getting SFDX AUTH FOR " + user)
 	cmd := exec.Command("sfdx", "force:org:display", "-u"+user, "--json")
 
 	stdout, err := cmd.StdoutPipe()

--- a/lib/soap.go
+++ b/lib/soap.go
@@ -54,7 +54,6 @@ func (s *Soap) ExecuteLogin(username, password string) (response []byte, err err
 
 	res, err := doRequest(req)
 	if err != nil {
-		fmt.Println(err)
 		return
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
Remove (most of) the direct logging to stdout/stderr in the lib module
by sending it to a Logger interface that can be overridden by library
users.

Cleans up spurious output in applications that use the library.