### PR TITLE
Deprecate Use Of Endpoint Constants

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -43,7 +43,7 @@ var (
 )
 
 func runLogin(cmd *Command, args []string) {
-	var endpoint string = "https://login.salesforce.com"
+	endpoint := "https://login.salesforce.com"
 	// If no instance specified, try to get last endpoint used
 	if *instance == "" {
 		currentEndpointUrl, err := CurrentEndpointUrl()

--- a/command/login.go
+++ b/command/login.go
@@ -43,15 +43,12 @@ var (
 )
 
 func runLogin(cmd *Command, args []string) {
-	var endpoint ForceEndpoint = EndpointProduction
+	var endpoint string = "https://login.salesforce.com"
 	// If no instance specified, try to get last endpoint used
 	if *instance == "" {
-		currentEndpoint, customUrl, err := CurrentEndpoint()
-		if err == nil && &currentEndpoint != nil {
-			endpoint = currentEndpoint
-			if currentEndpoint == EndpointCustom && customUrl != "" {
-				*instance = customUrl
-			}
+		currentEndpointUrl, err := CurrentEndpointUrl()
+		if err == nil && currentEndpointUrl != "" {
+			endpoint = currentEndpointUrl
 		}
 	}
 
@@ -66,13 +63,13 @@ func runLogin(cmd *Command, args []string) {
 
 	switch *instance {
 	case "login":
-		endpoint = EndpointProduction
+		endpoint = "https://login.salesforce.com"
 	case "test":
-		endpoint = EndpointTest
+		endpoint = "https://test.salesforce.com"
 	case "pre":
-		endpoint = EndpointPrerelease
+		endpoint = "https://prerelna1.salesforce.com"
 	case "mobile1":
-		endpoint = EndpointMobile1
+		endpoint = "https://mobile1.t.pre.salesforce.com"
 	default:
 		if *instance != "" {
 			//need to determine the form of the endpoint
@@ -88,16 +85,15 @@ func runLogin(cmd *Command, args []string) {
 					ErrorAndExit("Could not identify host: %s", *instance)
 				}
 			}
-			CustomEndpoint = uri.Scheme + "://" + uri.Host
-			endpoint = EndpointCustom
+			endpoint = uri.Scheme + "://" + uri.Host
 
-			fmt.Println("Loaded Endpoint: (" + CustomEndpoint + ")")
+			fmt.Println("Loaded Endpoint: (" + endpoint + ")")
 		}
 	}
 
 	if len(*userName) == 0 {
 		// OAuth Login
-		_, err := ForceLoginAndSave(endpoint, os.Stdout)
+		_, err := ForceLoginAtEndpointAndSave(endpoint, os.Stdout)
 		if err != nil {
 			ErrorAndExit(err.Error())
 		}
@@ -106,11 +102,11 @@ func runLogin(cmd *Command, args []string) {
 
 	if len(*keyFile) != 0 {
 		// JWT Login
-		assertion, err := JwtAssertion(endpoint, *userName, *keyFile, ClientId)
+		assertion, err := JwtAssertionForEndpoint(endpoint, *userName, *keyFile, ClientId)
 		if err != nil {
 			ErrorAndExit(err.Error())
 		}
-		_, err = ForceLoginAndSaveJWT(endpoint, assertion, os.Stdout)
+		_, err = ForceLoginAtEndpointAndSaveJWT(endpoint, assertion, os.Stdout)
 		if err != nil {
 			ErrorAndExit(err.Error())
 		}
@@ -125,13 +121,14 @@ func runLogin(cmd *Command, args []string) {
 			ErrorAndExit(err.Error())
 		}
 	}
-	_, err := ForceLoginAndSaveSoap(endpoint, *userName, *password, os.Stdout)
+	_, err := ForceLoginAtEndpointAndSaveSoap(endpoint, *userName, *password, os.Stdout)
 	if err != nil {
 		ErrorAndExit(err.Error())
 	}
 }
 
 func CurrentEndpoint() (endpoint ForceEndpoint, customUrl string, err error) {
+	Log.Info("Deprecated call to CurrentEndpoint.  Use CurrentEndpointUrl.")
 	creds, err := ActiveCredentials(false)
 	if err != nil {
 		return
@@ -139,4 +136,12 @@ func CurrentEndpoint() (endpoint ForceEndpoint, customUrl string, err error) {
 	endpoint = creds.ForceEndpoint
 	customUrl = creds.InstanceUrl
 	return
+}
+
+func CurrentEndpointUrl() (endpoint string, err error) {
+	creds, err := ActiveCredentials(false)
+	if err != nil {
+		return "", err
+	}
+	return creds.EndpointUrl, nil
 }

--- a/lib/jwt.go
+++ b/lib/jwt.go
@@ -13,6 +13,12 @@ import (
 )
 
 func JwtAssertion(endpoint ForceEndpoint, username string, keyfile string, clientId string) (signedToken string, err error) {
+	Log.Info("Deprecated call to JwtAssertion.  Use JwtAssertionForEndpoint.")
+	url := endpointUrl(endpoint)
+	return JwtAssertionForEndpoint(url, username, keyfile, clientId)
+}
+
+func JwtAssertionForEndpoint(endpoint string, username string, keyfile string, clientId string) (signedToken string, err error) {
 	keyData, err := ioutil.ReadFile(keyfile)
 	if err != nil {
 		return
@@ -22,10 +28,7 @@ func JwtAssertion(endpoint ForceEndpoint, username string, keyfile string, clien
 		return
 	}
 
-	tokenURL, err := tokenURL(endpoint)
-	if err != nil {
-		return
-	}
+	tokenURL := tokenURL(endpoint)
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"iss": clientId,
 		"sub": username,
@@ -37,15 +40,18 @@ func JwtAssertion(endpoint ForceEndpoint, username string, keyfile string, clien
 }
 
 func JWTLogin(endpoint ForceEndpoint, assertion string) (creds ForceSession, err error) {
-	if err != nil {
-		return
-	}
+	Log.Info("Deprecated call to JWTLogin.  Use JWTLoginAtEndpoint.")
+	url := endpointUrl(endpoint)
+	return JWTLoginAtEndpoint(url, assertion)
+}
+
+func JWTLoginAtEndpoint(endpoint string, assertion string) (creds ForceSession, err error) {
 	attrs := url.Values{}
 	attrs.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
 	attrs.Set("assertion", assertion)
 
 	postVars := attrs.Encode()
-	tokenURL, err := tokenURL(endpoint)
+	tokenURL := tokenURL(endpoint)
 	if err != nil {
 		return
 	}
@@ -76,13 +82,19 @@ func JWTLogin(endpoint ForceEndpoint, assertion string) (creds ForceSession, err
 
 	err = json.Unmarshal(body, &creds)
 	creds.SessionOptions = &SessionOptions{}
-	creds.ForceEndpoint = endpoint
+	creds.EndpointUrl = endpoint
 	creds.ClientId = ClientId
 	return
 }
 
 func ForceLoginAndSaveJWT(endpoint ForceEndpoint, assertion string, output *os.File) (username string, err error) {
-	creds, err := JWTLogin(endpoint, assertion)
+	Log.Info("Deprecated call to ForceLoginAndSaveJWT.  Use ForceLoginAtEndpointAndSaveJWT.")
+	url := endpointUrl(endpoint)
+	return ForceLoginAtEndpointAndSaveJWT(url, assertion, output)
+}
+
+func ForceLoginAtEndpointAndSaveJWT(endpoint string, assertion string, output *os.File) (username string, err error) {
+	creds, err := JWTLoginAtEndpoint(endpoint, assertion)
 	if err != nil {
 		return
 	}

--- a/lib/sfdx.go
+++ b/lib/sfdx.go
@@ -24,9 +24,9 @@ type SFDXAuth struct {
 
 func UseSFDXSession(authData SFDXAuth) {
 	creds := ForceSession{
-		AccessToken:   authData.AccessToken,
-		InstanceUrl:   authData.InstanceUrl,
-		ForceEndpoint: EndpointCustom,
+		AccessToken: authData.AccessToken,
+		InstanceUrl: authData.InstanceUrl,
+		EndpointUrl: authData.InstanceUrl,
 		UserInfo: &UserInfo{
 			OrgId: authData.Id,
 		},


### PR DESCRIPTION
Store endpoint with session information.  Deprecate use of
CustomEndpoint.

Fixes bugs in which user authenticates with a Custom Endpoint and then
cannot refresh the OAuth token because the endpoint used is not stored
with the session.