### PR TITLE
Update API version number

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -2,9 +2,10 @@ package command
 
 import (
 	"fmt"
-	"github.com/bgentry/speakeasy"
 	"net/url"
 	"os"
+
+	"github.com/bgentry/speakeasy"
 
 	. "github.com/ForceCLI/force/error"
 	. "github.com/ForceCLI/force/lib"
@@ -55,6 +56,9 @@ func runLogin(cmd *Command, args []string) {
 	if *api_version != "" {
 		// Todo verify format of version is 30.0
 		SetApiVersion(*api_version)
+	} else {
+		//override api version in case of a new login
+		SetApiVersion(DefaultApiVersionNumber)
 	}
 
 	if *connectedAppClientId != "" {

--- a/lib/apiversion.go
+++ b/lib/apiversion.go
@@ -5,8 +5,11 @@ import (
 	"os"
 )
 
-var apiVersionNumber = "40.0"
-var apiVersion = fmt.Sprintf("v%s", apiVersionNumber)
+var (
+	DefaultApiVersionNumber = "45.0"
+	apiVersionNumber        = DefaultApiVersionNumber
+	apiVersion              = fmt.Sprintf("v%s", apiVersionNumber)
+)
 
 func ApiVersion() string {
 	return apiVersion


### PR DESCRIPTION
Set new logins to API version number 45.0 if not specified. Existing sessions are not affected.