### PR TITLE
Report dangling arguments

### DIFF
--- a/command/active.go
+++ b/command/active.go
@@ -27,6 +27,7 @@ Options:
   -local, -l    Set active account locally, for current directory
   -session, -s  Output session id
 `,
+	MaxExpectedArgs: 1,
 }
 var (
 	tojson    bool

--- a/command/apex.go
+++ b/command/apex.go
@@ -27,6 +27,7 @@ Examples:
   >> Start typing Apex code; press CTRL-D(for Mac/Linux) / Ctrl-Z (for Windows) when finished
 
 `,
+	MaxExpectedArgs: 2,
 }
 
 func init() {

--- a/command/apiversion.go
+++ b/command/apiversion.go
@@ -20,6 +20,7 @@ Examples:
   force apiversion
   force apiversion 40.0
 `,
+	MaxExpectedArgs: 1,
 }
 
 func init() {

--- a/command/aura.go
+++ b/command/aura.go
@@ -52,6 +52,7 @@ var cmdAura = &Command{
 	force aura list
 
 	`,
+	MaxExpectedArgs: -1,
 }
 
 func init() {

--- a/command/bigobject.go
+++ b/command/bigobject.go
@@ -89,7 +89,7 @@ func runBigObject(cmd *Command, args []string) {
 			if len(args) <= 2 {
 				getBigObjectList(args[1:])
 			} else {
-				cmd.InvalidInvokation(args)
+				cmd.InvalidInvocation(args)
 			}
 		case "create":
 			runBigObjectCreate(args[1:])

--- a/command/bigobject.go
+++ b/command/bigobject.go
@@ -25,7 +25,7 @@ Usage:
   force bigobject create -n=<name> [-f=<field> ...]
   		A field is defined as a "+" separated list of attributes
   		Attributes depend on the type of the field.
-  		
+
   		Type = text: name, label, length
   		Type = datetime: name, label
   		Type = lookup: name, label, referenceTo, relationshipName
@@ -40,6 +40,7 @@ Examples:
   -f=name:MyDate+type=dateTime
 
 `,
+	MaxExpectedArgs: -1,
 }
 
 type boField []string
@@ -85,7 +86,11 @@ func runBigObject(cmd *Command, args []string) {
 		}
 		switch args[0] {
 		case "list":
-			getBigObjectList(args[1:])
+			if len(args) <= 2 {
+				getBigObjectList(args[1:])
+			} else {
+				cmd.InvalidInvokation(args)
+			}
 		case "create":
 			runBigObjectCreate(args[1:])
 		default:

--- a/command/bulk.go
+++ b/command/bulk.go
@@ -113,6 +113,7 @@ Examples using positional arguments - less flexible, arguments must be in the co
   force bulk query retrieve [job id] [batch id]
 
 `,
+	MaxExpectedArgs: -1,
 }
 
 var (

--- a/command/command.go
+++ b/command/command.go
@@ -81,7 +81,7 @@ func (c *Command) List() bool {
 	return c.Short != ""
 }
 
-func (c *Command) InvalidInvokation(args []string) {
-	fmt.Printf("Invalid invokation: force %s\n\n", strings.Join(args, " "))
+func (c *Command) InvalidInvocation(args []string) {
+	fmt.Printf("Invalid invocation: force %s\n\n", strings.Join(args, " "))
 	c.PrintUsage()
 }

--- a/command/command.go
+++ b/command/command.go
@@ -51,9 +51,10 @@ type Command struct {
 	Run  func(cmd *Command, args []string)
 	Flag flag.FlagSet
 
-	Usage string // first word is the command name
-	Short string // `forego help` output
-	Long  string // `forego help cmd` output
+	Usage           string // first word is the command name
+	Short           string // `forego help` output
+	Long            string // `forego help cmd` output
+	MaxExpectedArgs int    // the maximum number of arguments this command expects, -1 if it is variadic
 }
 
 func (c *Command) PrintUsage() {
@@ -78,4 +79,9 @@ func (c *Command) Runnable() bool {
 
 func (c *Command) List() bool {
 	return c.Short != ""
+}
+
+func (c *Command) InvalidInvokation(args []string) {
+	fmt.Printf("Invalid invokation: force %s\n\n", strings.Join(args, " "))
+	c.PrintUsage()
 }

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,9 +1,10 @@
 package command_test
 
 import (
+	"testing"
+
 	. "github.com/ForceCLI/force/command"
 	"github.com/bmizerany/assert"
-	"testing"
 )
 
 // test that all avialable commands come with at least a name and short usage information

--- a/command/create.go
+++ b/command/create.go
@@ -24,6 +24,7 @@ Examples:
 
   force create -t ApexComponent -n CoolComponent
 `,
+	MaxExpectedArgs: 0,
 }
 var (
 	what        string

--- a/command/datapipe.go
+++ b/command/datapipe.go
@@ -33,7 +33,7 @@ Commands:
   create        creates a new dataPipe
   update        update a dataPipe
   delete        delete a datapipe
-  list          list all datapipes 
+  list          list all datapipes
   query         query for a specific datapipe(s)
   createjob     creates a new job for a specific datapipe
   listjobs      list the status of submitted jobs
@@ -53,6 +53,7 @@ Defaults
   -v Current API version *Number only
 
 `,
+	MaxExpectedArgs: -1,
 }
 
 var defaultContent = `
@@ -99,6 +100,7 @@ func runDataPipe(cmd *Command, args []string) {
 		if err := cmd.Flag.Parse(args[1:]); err != nil {
 			os.Exit(2)
 		}
+
 		switch args[0] {
 		case "create":
 			runDataPipelineCreate()

--- a/command/describe.go
+++ b/command/describe.go
@@ -19,6 +19,7 @@ var cmdDescribe = &Command{
   force describe -t=metadata -n=CustomObject
   force describe -t=sobject -n=Account
   `,
+	MaxExpectedArgs: 0,
 }
 
 var (

--- a/command/eventlogfile.go
+++ b/command/eventlogfile.go
@@ -18,6 +18,7 @@ Examples:
   force eventlogfile
   force eventlogfile 0AT300000000XQ7GAM
 `,
+	MaxExpectedArgs: 1,
 }
 
 func getEventLogFile(cmd *Command, args []string) {

--- a/command/export.go
+++ b/command/export.go
@@ -32,6 +32,7 @@ Examples:
 
   force export -x ApexClass -x CustomObject
 `,
+	MaxExpectedArgs: 1,
 }
 
 type metadataList []string

--- a/command/fetch.go
+++ b/command/fetch.go
@@ -37,6 +37,7 @@ Examples
   force fetch -t AuraDefinitionBundle -t ApexClass
   force fetch -x myproj/metadata/package.xml
 `,
+	MaxExpectedArgs: 0,
 }
 
 type metaName []string

--- a/command/field.go
+++ b/command/field.go
@@ -33,6 +33,7 @@ Examples:
   force field type email   #displays the required and optional attributes
 
 `,
+	MaxExpectedArgs: -1,
 }
 
 func runField(cmd *Command, args []string) {
@@ -51,6 +52,8 @@ func runField(cmd *Command, args []string) {
 				DisplayFieldTypes()
 			} else if len(args) == 2 {
 				DisplayFieldDetails(args[1])
+			} else {
+				ErrorAndExit("must specify one type at most")
 			}
 		default:
 			ErrorAndExit("no such command: %s", args[0])
@@ -105,8 +108,8 @@ func runFieldCreate(args []string) {
 }
 
 func runFieldDelete(args []string) {
-	if len(args) < 2 {
-		ErrorAndExit("must specify object and at least one field")
+	if len(args) != 2 {
+		ErrorAndExit("must specify object and field")
 	}
 	force, _ := ActiveForce()
 	if err := force.Metadata.DeleteCustomField(args[0], args[1]); err != nil {

--- a/command/help.go
+++ b/command/help.go
@@ -9,9 +9,10 @@ import (
 )
 
 var cmdHelp = &Command{
-	Usage: "help [topic]",
-	Short: "Show this help",
-	Long:  `Help shows usage for a command.`,
+	Usage:           "help [topic]",
+	Short:           "Show this help",
+	Long:            `Help shows usage for a command.`,
+	MaxExpectedArgs: -1,
 }
 
 func init() {

--- a/command/import.go
+++ b/command/import.go
@@ -40,6 +40,7 @@ Examples:
 
   force import -checkonly -runalltests
 `,
+	MaxExpectedArgs: -1,
 }
 
 var (

--- a/command/limits.go
+++ b/command/limits.go
@@ -17,6 +17,7 @@ var cmdLimits = &Command{
 	 -- Max is the limit total for the organization.
 
 	 -- Remaining is the total number of calls or events left for the organization.`,
+	MaxExpectedArgs: 0,
 }
 
 func init() {

--- a/command/log.go
+++ b/command/log.go
@@ -22,6 +22,7 @@ Examples:
 
   force log delete <id>
 `,
+	MaxExpectedArgs: -1,
 }
 
 func init() {
@@ -44,6 +45,8 @@ func getLog(cmd *Command, args []string) {
 			ErrorAndExit(err.Error())
 		}
 		fmt.Println("Debug log deleted")
+	} else if len(args) > 1 {
+		ErrorAndExit("You need to provide the id of a debug log to fetch.")
 	} else {
 		logId := args[0]
 		log, err := force.RetrieveLog(logId)

--- a/command/login.go
+++ b/command/login.go
@@ -26,6 +26,7 @@ var cmdLogin = &Command{
     force login -i my-domain.my.salesforce.com -u username -p password
     force login --connected-app-client-id <my-consumer-key> -u username -key jwt.key
 `,
+	MaxExpectedArgs: 0,
 }
 
 func init() {

--- a/command/logins.go
+++ b/command/logins.go
@@ -22,6 +22,7 @@ Examples:
 
   force logins
 `,
+	MaxExpectedArgs: 0,
 }
 
 func runLogins(cmd *Command, args []string) {

--- a/command/logout.go
+++ b/command/logout.go
@@ -23,6 +23,7 @@ Examples:
   force logout
   force logout -u=user@example.org
 `,
+	MaxExpectedArgs: 0,
 }
 
 func init() {

--- a/command/notify.go
+++ b/command/notify.go
@@ -14,6 +14,7 @@ var cmdNotifySet = &Command{
 	Long: `
 Determines if notifications should be used
 `,
+	MaxExpectedArgs: -1,
 }
 
 func notifySet(cmd *Command, args []string) {

--- a/command/oauth.go
+++ b/command/oauth.go
@@ -22,6 +22,7 @@ Examples:
 
   force oauth create MyApp http://localhost:3835/oauth/callback
 `,
+	MaxExpectedArgs: -1,
 }
 
 func runOauth(cmd *Command, args []string) {

--- a/command/open.go
+++ b/command/open.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+
 	desktop "github.com/ForceCLI/force/desktop"
 	. "github.com/ForceCLI/force/error"
 	. "github.com/ForceCLI/force/lib"
@@ -16,6 +17,7 @@ By default, the active account is used.
 
   force open [account]
 `,
+	MaxExpectedArgs: 1,
 }
 
 func init() {

--- a/command/package.go
+++ b/command/package.go
@@ -21,6 +21,7 @@ Usage:
 Options:
   -activate, -a     Keep the isActive state of any Remote Site Settings (RSS) and Content Security Policies (CSP) in package
 `,
+	MaxExpectedArgs: 4,
 }
 
 var (

--- a/command/password.go
+++ b/command/password.go
@@ -23,6 +23,7 @@ Examples:
   force password change joe@org.com $uP3r$3cure
 
 `,
+	MaxExpectedArgs: -1,
 }
 
 func init() {

--- a/command/push.go
+++ b/command/push.go
@@ -22,7 +22,7 @@ var cmdPush = &Command{
 	Usage: "push -t <metadata type> -n <metadata name> -f <pathtometadata> [deployment options]",
 	Short: "Deploy artifact from a local directory",
 	Long: `
-Deploy artifact from a local directory 
+Deploy artifact from a local directory
 <metadata>: Accepts either actual directory name or Metadata type
 File path can be specified as - to read from stdin; see examples
 
@@ -45,6 +45,7 @@ Deployment Options
   -testlevel, -l          Set test level (NoTestRun, RunSpecifiedTests, RunLocalTests, RunAllTestsInOrg)
   -ignorewarnings, -i     Indicates if warnings should fail deployment or not
 `,
+	MaxExpectedArgs: -1,
 }
 
 var (

--- a/command/pushAura.go
+++ b/command/pushAura.go
@@ -21,6 +21,7 @@ var cmdPushAura = &Command{
 	force pushAura -f=<fullFilePath>
 
 	`,
+	MaxExpectedArgs: -1,
 }
 
 func init() {

--- a/command/query.go
+++ b/command/query.go
@@ -2,9 +2,10 @@ package command
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	. "github.com/ForceCLI/force/error"
 	. "github.com/ForceCLI/force/lib"
@@ -29,6 +30,7 @@ Query Options
   --tooling, -t  Use Tooling API
   --format, -f   Output format: csv, json, json-pretty, console
 `,
+	MaxExpectedArgs: -1,
 }
 
 var (

--- a/command/quickdeploy.go
+++ b/command/quickdeploy.go
@@ -23,6 +23,7 @@ Examples:
 
   force quickdeploy -v 0Af0b000000ZvXH
 `,
+	MaxExpectedArgs: -1,
 }
 
 var (

--- a/command/record.go
+++ b/command/record.go
@@ -45,6 +45,7 @@ Examples:
 
   force record delete User 00Ei0000000000
 `,
+	MaxExpectedArgs: -1,
 }
 
 func runRecord(cmd *Command, args []string) {

--- a/command/rest.go
+++ b/command/rest.go
@@ -28,6 +28,7 @@ Examples:
   force rest post "/tooling/sobjects/CustomField/00D9A0000000TgcUAE" path/to/definition.json
 
 `,
+	MaxExpectedArgs: -1,
 }
 
 var (
@@ -46,6 +47,7 @@ func runRest(cmd *Command, args []string) {
 		err  error
 	)
 	force, _ := ActiveForce()
+
 	if len(args) == 0 {
 		cmd.PrintUsage()
 	} else if strings.ToLower(args[0]) == "get" {

--- a/command/security.go
+++ b/command/security.go
@@ -244,6 +244,7 @@ Examples:
 
   force security Case
 `,
+	MaxExpectedArgs: -1,
 }
 
 func runSecurity(cmd *Command, args []string) {
@@ -258,7 +259,7 @@ func runSecurity(cmd *Command, args []string) {
 			{Name: []string{"CustomObject"}, Members: args},
 		}
 	} else {
-		fmt.Printf("Pass an SObject name")
+		fmt.Println("Pass an SObject name")
 		return
 	}
 

--- a/command/sobject.go
+++ b/command/sobject.go
@@ -38,6 +38,7 @@ Examples:
 
   force sobject delete Todo
 `,
+	MaxExpectedArgs: -1,
 }
 
 func runSobject(cmd *Command, args []string) {

--- a/command/test.go
+++ b/command/test.go
@@ -3,10 +3,11 @@ package command
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/ForceCLI/force/desktop"
 	. "github.com/ForceCLI/force/error"
 	. "github.com/ForceCLI/force/lib"
-	"strings"
 )
 
 var cmdTest = &Command{
@@ -29,6 +30,7 @@ Examples:
   force test -class=Test1 method1 method2
   force test -v Test1
 `,
+	MaxExpectedArgs: -1,
 }
 
 func init() {

--- a/command/trace.go
+++ b/command/trace.go
@@ -22,6 +22,7 @@ Examples:
 
   force trace delete <id>
 `,
+	MaxExpectedArgs: -1,
 }
 
 func init() {

--- a/command/usedxauth.go
+++ b/command/usedxauth.go
@@ -3,11 +3,12 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	. "github.com/ForceCLI/force/error"
-	. "github.com/ForceCLI/force/lib"
 	"os"
 	"os/exec"
 	"path"
+
+	. "github.com/ForceCLI/force/error"
+	. "github.com/ForceCLI/force/lib"
 )
 
 var cmdUseDXAuth = &Command{
@@ -23,6 +24,7 @@ Examples:
   force usedxauth ScratchUserAlias
   force usedxauth
 `,
+	MaxExpectedArgs: 1,
 }
 
 func init() {

--- a/command/version.go
+++ b/command/version.go
@@ -18,6 +18,7 @@ Examples:
 
   force version
 `,
+	MaxExpectedArgs: 0,
 }
 
 func init() {

--- a/command/whoami.go
+++ b/command/whoami.go
@@ -16,6 +16,7 @@ Examples:
 
   force whoami
 `,
+	MaxExpectedArgs: 0,
 }
 
 func runWhoami(cmd *Command, args []string) {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,11 @@ func main() {
 			if err := cmd.Flag.Parse(args[1:]); err != nil {
 				os.Exit(2)
 			}
+			if cmd.MaxExpectedArgs >= 0 && len(cmd.Flag.Args()) > cmd.MaxExpectedArgs {
+				cmd.InvalidInvokation(args)
+				os.Exit(2)
+			}
+
 			_, err := ActiveCredentials(false)
 			if err != nil {
 				ErrorAndExit(err.Error())

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 				os.Exit(2)
 			}
 			if cmd.MaxExpectedArgs >= 0 && len(cmd.Flag.Args()) > cmd.MaxExpectedArgs {
-				cmd.InvalidInvokation(args)
+				cmd.InvalidInvocation(args)
 				os.Exit(2)
 			}
 


### PR DESCRIPTION
Added `MaxExpectedArgs` to `command.Command`. After parsing flags, if the remaining arguments are greater than expected, exit with an error status.

This will prevent situations like `force fetch -t Metadata MetadataName` where the default action is not probably not the expected outcome.

For commands that already check their arguments or take a variadic amount of arguments `MaxExpectedArgs` is -1.