### PR TITLE
Expose Force field variable through getters

### DIFF
--- a/lib/force.go
+++ b/lib/force.go
@@ -1599,3 +1599,15 @@ func oauthCallbackHtml() string {
   </body>
 </html>`
 }
+
+func (force *Force) GetMetadata() *ForceMetadata {
+	return force.Metadata
+}
+
+func (force *Force) GetCredentials() *ForceSession {
+	return force.Credentials
+}
+
+func (force *Force) GetPartner() *ForcePartner {
+	return force.Partner
+}


### PR DESCRIPTION
This handle enables mockup interfaces of `lib.Force` (for example, testing) to use the methods implemented for the field variables.