### PR TITLE
Fix Aggregate Queries

### DIFF
--- a/lib/query/query.go
+++ b/lib/query/query.go
@@ -50,7 +50,7 @@ func recordFromMapRecord(q queryer, rec map[string]interface{}) (Record, error) 
 		if k == "attributes" {
 			attrs := v.(map[string]interface{})
 			res.Attributes.Type = attrs["type"].(string)
-			res.Attributes.Url = attrs["url"].(string)
+			res.Attributes.Url, _ = attrs["url"].(string)
 		} else if vm, ok := v.(map[string]interface{}); ok && vm["records"] != nil {
 			if _, isRelationList := vm["done"]; isRelationList {
 				subrecs, err := recordsFromMapRecords(q, toStrIfaceMapSlice(vm["records"].([]interface{})))


### PR DESCRIPTION
Fix panic when running a SOQL query with an aggregate function due to
the url attribute not being set for the aggregate value.