### PR TITLE
Extra information for BatchChunkResult

### DIFF
--- a/lib/bulk.go
+++ b/lib/bulk.go
@@ -14,6 +14,8 @@ type BatchResult struct {
 
 type BatchResultChunk struct {
 	HasCSVHeader bool
+	Finished     bool
+	BatchId      string
 	Data         []byte
 }
 


### PR DESCRIPTION
Feed the channel on `force.httpGetRequestAndSend` finer grained information about the chunk process.