### PR TITLE
Add http callback support, cleanup (LP 56260286)

### DIFF
--- a/lib/auth.go
+++ b/lib/auth.go
@@ -13,7 +13,7 @@ import (
 
 func (f *Force) userInfo() (userinfo UserInfo, err error) {
 	url := fmt.Sprintf("%s/services/oauth2/userinfo", f.Credentials.InstanceUrl)
-	login, err := f.httpGet(url)
+	login, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
 	if err != nil {
 		return
 	}

--- a/lib/bulk_test.go
+++ b/lib/bulk_test.go
@@ -1,0 +1,54 @@
+package lib_test
+
+import (
+	. "github.com/ForceCLI/force/lib"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+	"net/http"
+)
+
+var _ = Describe("bulk", func() {
+	var sfServer *Server
+	var f *Force
+
+	BeforeEach(func() {
+		sfServer = NewServer()
+		f = NewForce(&ForceSession{InstanceUrl: sfServer.URL()})
+	})
+	AfterEach(func() {
+		sfServer.Close()
+	})
+
+	jobInfo := JobInfo{ContentType: string(JobContentTypeJson)}
+	Describe("RetrieveBulkJobQueryResultsWithCallback", func() {
+
+		It("invokes the callback with the response", func() {
+			sfServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest("GET", "/services/async/45.0/job//batch/batch1/result/result1"),
+					RespondWith(200, "abc"),
+				),
+			)
+
+			f := NewForce(&ForceSession{InstanceUrl: sfServer.URL()})
+			called := false
+			cb := func(res *http.Response) error {
+				Expect(mustRead(res.Body)).To(BeEquivalentTo("abc"))
+				called = true
+				return nil
+			}
+			Expect(f.RetrieveBulkJobQueryResultsWithCallback(jobInfo, "batch1", "result1", cb)).To(Succeed())
+			Expect(called).To(BeTrue())
+		})
+		It("propagates errors", func() {
+			sfServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest("GET", "/services/async/45.0/job//batch/batch1/result/result1"),
+					RespondWith(400, "whoops"),
+				),
+			)
+			Expect(f.RetrieveBulkJobQueryResultsWithCallback(jobInfo, "batch1", "result1", nil)).To(MatchError("whoops"))
+		})
+	})
+})

--- a/lib/httpaux.go
+++ b/lib/httpaux.go
@@ -1,0 +1,102 @@
+package lib
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+type ContentType string
+
+const (
+	ContentTypeNone = ""
+	ContentTypeJson = "application/json"
+	ContentTypeXml  = "application/xml"
+	ContentTypeCsv  = "application/csv"
+)
+
+func doRequest(request *http.Request) (res *http.Response, err error) {
+	client := &http.Client{}
+	client.Timeout = time.Duration(Timeout) * time.Millisecond
+	return client.Do(request)
+}
+
+func httpRequest(method, url string, body io.Reader) (request *http.Request, err error) {
+	return httpRequestWithHeaders(method, url, nil, body)
+}
+
+func httpRequestWithHeaders(method, url string, headers map[string]string, body io.Reader) (request *http.Request, err error) {
+	request, err = http.NewRequest(method, url, body)
+	if err != nil {
+		return
+	}
+	request.Header.Add("User-Agent", fmt.Sprintf("force/%s (%s-%s)", Version, runtime.GOOS, runtime.GOARCH))
+	for k, v := range headers {
+		request.Header.Set(k, v)
+	}
+	return
+}
+
+type httpRequestInput struct {
+	Method   string
+	Url      string
+	Headers  map[string]string
+	Callback HttpCallback
+	Retrier  *httpRetrier
+	Body     io.Reader
+}
+
+func (r *httpRequestInput) WithCallback(cb HttpCallback) *httpRequestInput {
+	r.Callback = cb
+	return r
+}
+
+func (r *httpRequestInput) WithHeader(k, v string) *httpRequestInput {
+	r.Headers[k] = v
+	return r
+}
+
+func (r *httpRequestInput) WithContent(ct ContentType) *httpRequestInput {
+	return r.WithHeader("Content-Type", string(ct))
+}
+
+// HttpCallback is called after a successful HTTP request.
+// The caller is responsible for closing the response body when it's finished.
+type HttpCallback func(*http.Response) error
+
+type httpRetrier struct {
+	attempt       int
+	maxAttempts   int
+	retryOnErrors []error
+}
+
+func (r *httpRetrier) Reauth() *httpRetrier {
+	if r.maxAttempts == 0 {
+		r.maxAttempts = 1
+	}
+	r.retryOnErrors = append(r.retryOnErrors, SessionExpiredError)
+	return r
+}
+
+func (r *httpRetrier) Attempts(max int) *httpRetrier {
+	r.maxAttempts = max
+	return r
+}
+
+func (r *httpRetrier) ShouldRetry(res *http.Response, err error) bool {
+	if err == nil {
+		return false
+	}
+	if r.attempt >= r.maxAttempts {
+		return false
+	}
+	r.attempt += 1
+	for _, e := range r.retryOnErrors {
+		if err == e {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/lib_suite_test.go
+++ b/lib/lib_suite_test.go
@@ -3,6 +3,9 @@ package lib_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io"
+	"io/ioutil"
+	"os"
 
 	"testing"
 )
@@ -10,4 +13,18 @@ import (
 func TestLib(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Lib Suite")
+}
+
+func mustWrite(path, contents string) {
+	Expect(ioutil.WriteFile(path, []byte(contents), 0644)).To(Succeed())
+}
+
+func mustMkdir(path string) {
+	Expect(os.MkdirAll(path, 0755)).To(Succeed())
+}
+
+func mustRead(r io.Reader) []byte {
+	b, err := ioutil.ReadAll(r)
+	Expect(err).ToNot(HaveOccurred())
+	return b
 }

--- a/lib/packagebuilder_test.go
+++ b/lib/packagebuilder_test.go
@@ -235,11 +235,3 @@ var _ = Describe("Packagebuilder", func() {
 		})
 	})
 })
-
-func mustWrite(path, contents string) {
-	Expect(ioutil.WriteFile(path, []byte(contents), 0644)).To(Succeed())
-}
-
-func mustMkdir(path string) {
-	Expect(os.MkdirAll(path, 0755)).To(Succeed())
-}

--- a/lib/record_reader/csv_record_reader.go
+++ b/lib/record_reader/csv_record_reader.go
@@ -1,0 +1,98 @@
+package record_reader
+
+import (
+	"bytes"
+	"encoding/csv"
+	"io"
+)
+
+// NewCsv returns a record reader that reports each CSV row as a record.
+// Note that CSV rows are not just delimited via '\n'-
+// there is in fact no way to know whether a character is inline a record
+// without having parsed the file (consider that newlines can be within cells,
+// and quotes are escaped via doubling-up, so even something like `","`
+// may refer to the string `","` within a cell, or `"",""` in the CSV).
+func NewCsv(in io.Reader, opts *Options) RecordReader {
+	bareOpts := initOptions(opts)
+	csvInputReader := csv.NewReader(in)
+	// We write the row to bytes as soon as we get it
+	csvInputReader.ReuseRecord = true
+	buf := bytes.NewBuffer(nil)
+	return &csvRecordReader{
+		options:        bareOpts,
+		csvInputReader: csvInputReader,
+		buf:            buf,
+		csvBuf:         csv.NewWriter(buf),
+	}
+}
+
+type csvRecordReader struct {
+	csvInputReader *csv.Reader
+	options        Options
+	buf            *bytes.Buffer
+	csvBuf         *csv.Writer
+	rowsInBuf      int
+	pendingError   error
+}
+
+func (c *csvRecordReader) Next() (RecordGroup, error) {
+	// We don't want to return any records plus an error,
+	// so if an error occurs during reading, we need to store it
+	// and return it when we don't have any records to report.
+	if c.pendingError != nil {
+		return RecordGroup{}, c.pendingError
+	}
+
+	for {
+		csvRow, err := c.csvInputReader.Read()
+		if err != nil {
+			// err can be EOF here, which is fine, we'll store for later
+			c.pendingError = err
+			// If the underlying reader was broken, and returned partial results,
+			// the CSV reader will error during the parse.
+			// This is because the bufio buffer used by the CSV reader internally
+			// will return the read bytes from Read(), and then return the error.
+			//
+			// We don't really want the parsing error due to the partial row returned;
+			// we want the underyling error from the broken reader.
+			// To get that error, we need to call .Read() *again*.
+			// This will cause CSV reader to make another call to the bufio buffer,
+			// which will now return the underlying reader error.
+			//
+			// If there is no underlying error, and the parse error was due to actual malformed CSV,
+			// we'll end up reporting that.
+			if _, isParserError := err.(*csv.ParseError); isParserError {
+				if _, nextCsvError := c.csvInputReader.Read(); nextCsvError != nil && nextCsvError != io.EOF {
+					c.pendingError = nextCsvError
+				}
+			}
+			if c.rowsInBuf > 0 {
+				// Next call will return the error
+				return c.commitAndResetBuffer(), nil
+			}
+			return RecordGroup{}, c.pendingError
+		}
+		if err := c.addPendingRow(csvRow); err != nil {
+			return RecordGroup{}, err
+		}
+		if c.rowsInBuf == c.options.GroupSize {
+			return c.commitAndResetBuffer(), nil
+		}
+	}
+}
+
+func (c *csvRecordReader) addPendingRow(row []string) error {
+	c.rowsInBuf++
+	return c.csvBuf.Write(row)
+}
+
+func (c *csvRecordReader) commitAndResetBuffer() RecordGroup {
+	c.csvBuf.Flush()
+	grp := RecordGroup{
+		Count: c.rowsInBuf,
+		Bytes: c.buf.Bytes(),
+	}
+	c.rowsInBuf = 0
+	c.buf.Reset()
+	return grp
+}

--- a/lib/record_reader/json_record_reader.go
+++ b/lib/record_reader/json_record_reader.go
@@ -1,0 +1,118 @@
+package record_reader
+
+import (
+	"bufio"
+	"io"
+)
+
+const expectedJsonRecordSize = 2048
+
+// NewJson returns a record reader that parses Apex-flavor JSON
+// and converts it into bytes of JSONLines format in its records.
+//
+// Note this is not a generic JSON parser- we cannot parse the JSON
+// both because it'd be slower, but especially because it's not really possible
+// to parse JSON like `[{}, {}]` incrementally. So we read lines
+// and figure out when we are between objects.
+//
+// Becuase of this, only Apex-flavor pretty JSON is supported. Like:
+//
+// [ {
+//      "x": 1
+// }, {
+//      "x: 2
+// } ]
+func NewJson(in io.Reader, opts *Options) RecordReader {
+	bareOpts := initOptions(opts)
+	return &jsonRecordReader{
+		options:          bareOpts,
+		scanner:          bufio.NewScanner(in),
+		buf:              make([]byte, 0, expectedJsonRecordSize*bareOpts.GroupSize),
+		pendingRecordBuf: make([]byte, 0, expectedJsonRecordSize),
+	}
+}
+
+type jsonRecordReader struct {
+	scanner          *bufio.Scanner
+	options          Options
+	buf              []byte
+	recordsInBuf     int
+	pendingRecordBuf []byte
+	pendingError     error
+}
+
+func (j *jsonRecordReader) Next() (RecordGroup, error) {
+	if j.pendingError != nil {
+		return RecordGroup{}, j.pendingError
+	}
+	j.buf = j.buf[:0]
+	j.recordsInBuf = 0
+
+	hasFinishedPendingRecord := true
+	for j.scanner.Scan() {
+		line := j.scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		firstChar := line[0]
+		lastChar := line[len(line)-1]
+		if firstChar == '[' && lastChar == '{' {
+			// First char in file is going to be opening JSON list, skip it
+			// ^[ {$
+			j.pendingRecordBuf = append(j.pendingRecordBuf, line[2:]...)
+			hasFinishedPendingRecord = false
+		} else if firstChar == '}' && lastChar == ']' {
+			// Final char in file is ending JSON list, skip it
+			// ^} ]$
+			j.pendingRecordBuf = append(j.pendingRecordBuf, line[:len(line)-2]...)
+			hasFinishedPendingRecord = true
+		} else if firstChar == '}' && lastChar == '{' {
+			// Separator between records in the list
+			// ^}, {$
+			j.pendingRecordBuf = append(j.pendingRecordBuf, '}')
+			hasFinishedPendingRecord = true
+		} else {
+			// All other lines are part of a normal record
+			j.pendingRecordBuf = append(j.pendingRecordBuf, line...)
+			hasFinishedPendingRecord = false
+		}
+
+		if hasFinishedPendingRecord {
+			j.commitPending()
+			if j.recordsInBuf == j.options.GroupSize {
+				return j.createGroup(), nil
+			}
+		}
+	}
+	scanErr := j.scanner.Err()
+	if scanErr != nil {
+		// This will never be EOF
+		j.pendingError = scanErr
+	} else if !hasFinishedPendingRecord {
+		// We may get no reader error, but not have completed out record
+		j.pendingError = ErrIncompleteRecord
+	}
+	if j.recordsInBuf > 0 {
+		return j.createGroup(), nil
+	}
+	if j.pendingError != nil {
+		return RecordGroup{}, j.pendingError
+	}
+	// Scanner gave us no error, and we completed our records, so we can assume we're at EOF.
+	return RecordGroup{}, io.EOF
+}
+
+func (j *jsonRecordReader) commitPending() {
+	j.recordsInBuf++
+	j.buf = append(j.buf, j.pendingRecordBuf...)
+	j.buf = append(j.buf, '\n')
+	// And reset the pending records buffer
+	j.pendingRecordBuf = j.pendingRecordBuf[:1]
+	j.pendingRecordBuf[0] = '{'
+}
+
+func (j *jsonRecordReader) createGroup() RecordGroup {
+	bufcop := make([]byte, len(j.buf))
+	copy(bufcop, j.buf)
+	return RecordGroup{Bytes: bufcop, Count: j.recordsInBuf}
+}

--- a/lib/record_reader/record_reader.go
+++ b/lib/record_reader/record_reader.go
@@ -1,0 +1,71 @@
+// Module record_reader supports incremental parsing io.Reader streams
+// into complete CSV or JSON records, so that you can callers
+// will never be left writing out invalid data (incomplete CSV row or JSON object).
+//
+// The logic for how this is done is very particular to the format,
+// so refer to the code for explanations.
+
+package record_reader
+
+import (
+	"errors"
+	"io"
+)
+
+var ErrIncompleteRecord = errors.New("stream finished in the middle of a record")
+
+const defaultGroupSize = 8
+
+// RecordGroup is a complete chunk of records read from the reader.
+// Its bytes can be safely written.
+type RecordGroup struct {
+	// The bytes of all the records in the group.
+	Bytes []byte
+	// The number of records present in the bytes.
+	Count int
+}
+
+type RecordReader interface {
+	// Next returns the bytes for the next chunk of records,
+	// or an error. error will never be non-nil
+	// if the group bytes are > 0.
+	Next() (RecordGroup, error)
+}
+
+type Options struct {
+	// The max number of records in a RecordGroup.
+	// Higher numbers will use more memory.
+	GroupSize int
+}
+
+func initOptions(op *Options) Options {
+	if op == nil {
+		op = &Options{}
+	}
+	o := *op
+	if o.GroupSize <= 0 {
+		o.GroupSize = defaultGroupSize
+	}
+	return o
+}
+
+// ReadAll returns a record group that has read every record
+// from the given reader, stopping after the first error.
+//
+// Note that unlike RecordReader.Next, if an error occurs,
+// the RecordGroup would have non-empty bytes
+// (if there are any records in the reader stream).
+func ReadAll(rr RecordReader) (RecordGroup, error) {
+	var composite RecordGroup
+	for {
+		grp, err := rr.Next()
+		if err == io.EOF {
+			return composite, nil
+		}
+		if err != nil {
+			return composite, err
+		}
+		composite.Count += grp.Count
+		composite.Bytes = append(composite.Bytes, grp.Bytes...)
+	}
+}

--- a/lib/record_reader/record_reader_test.go
+++ b/lib/record_reader/record_reader_test.go
@@ -1,0 +1,132 @@
+package record_reader_test
+
+import (
+	"encoding/csv"
+	"errors"
+	"github.com/ForceCLI/force/lib/record_reader"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRecordReader(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RecordReader Suite")
+}
+
+var _ = Describe("CsvRecordReader", func() {
+	var validStream = `ColumnA,ColumnB,ColumnC
+A1,B1,C1
+A2,B2,C2
+A3,B3,C3
+`
+	var invalidStream = validStream + "A4,\n"
+
+	It("invokes the callback for all records in a valid stream", func() {
+		r := record_reader.NewCsv(sreader(validStream), nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(validStream))
+		Expect(recs.Count).To(BeEquivalentTo(4))
+	})
+	It("provides and error and discards last record of an invalid stream", func() {
+		r := record_reader.NewCsv(sreader(invalidStream), nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).To(BeAssignableToTypeOf(&csv.ParseError{}))
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(validStream))
+		Expect(recs.Count).To(BeEquivalentTo(4))
+	})
+	It("provides an error on a broken but complete stream", func() {
+		r := record_reader.NewCsv(&brokenReader{sreader(validStream)}, nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).To(BeIdenticalTo(brokenReaderErr))
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(validStream))
+		Expect(recs.Count).To(BeEquivalentTo(4))
+	})
+	It("provides an error and discards the last record on a broken, incomplete stream", func() {
+		r := record_reader.NewCsv(&brokenReader{sreader(invalidStream)}, nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).To(BeIdenticalTo(brokenReaderErr))
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(validStream))
+		Expect(recs.Count).To(BeEquivalentTo(4))
+	})
+})
+
+var _ = Describe("JsonRecordReader", func() {
+	var startOfStream = `[ {
+  "attributes" : {
+    "type" : "Account"
+  },
+  "Id" : "ID1",
+  "OwnerId" : "ID2"
+}, {
+  "attributes" : {
+    "type" : "Account"
+  },
+  "Id" : "ID3",
+  "OwnerId" : "ID4"
+}`
+	var validStream = startOfStream + " ]"
+	var invalidStream = startOfStream + `, {
+  "attributes" : {
+    "type" : "Account",`
+	var expectedLines = `{  "attributes" : {    "type" : "Account"  },  "Id" : "ID1",  "OwnerId" : "ID2"}
+{  "attributes" : {    "type" : "Account"  },  "Id" : "ID3",  "OwnerId" : "ID4"}
+`
+
+	It("invokes the callback for all records in a valid stream", func() {
+		r := record_reader.NewJson(sreader(validStream), nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(expectedLines))
+		Expect(recs.Count).To(BeEquivalentTo(2))
+	})
+	It("can work across multiple batches of records", func() {
+		r := record_reader.NewJson(sreader(validStream), &record_reader.Options{GroupSize: 1})
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(expectedLines))
+		Expect(recs.Count).To(BeEquivalentTo(2))
+	})
+	It("detects error and discards last record of an invalid stream", func() {
+		r := record_reader.NewJson(sreader(invalidStream), nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).To(BeIdenticalTo(record_reader.ErrIncompleteRecord))
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(expectedLines))
+		Expect(recs.Count).To(BeEquivalentTo(2))
+	})
+	It("provides an error on a broken but complete stream", func() {
+		r := record_reader.NewJson(&brokenReader{sreader(validStream)}, nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).To(BeIdenticalTo(brokenReaderErr))
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(expectedLines))
+		Expect(recs.Count).To(BeEquivalentTo(2))
+	})
+	It("provides an error and discards the last record on a broken, incomplete stream", func() {
+		r := record_reader.NewJson(&brokenReader{sreader(invalidStream)}, nil)
+		recs, err := record_reader.ReadAll(r)
+		Expect(err).To(BeIdenticalTo(brokenReaderErr))
+		Expect(string(recs.Bytes)).To(BeEquivalentTo(expectedLines))
+		Expect(recs.Count).To(BeEquivalentTo(2))
+	})
+})
+
+func sreader(s string) io.Reader {
+	return strings.NewReader(s)
+}
+
+var brokenReaderErr = errors.New("BrokenReader fake error")
+
+type brokenReader struct {
+	Buffer io.Reader
+}
+
+func (b *brokenReader) Read(p []byte) (int, error) {
+	n, err := b.Buffer.Read(p)
+	if err == io.EOF {
+		return n, brokenReaderErr
+	}
+	return n, err
+}


### PR DESCRIPTION
The original goal of this PR was to add support for a callback,
passed into RetrieveBulkJobQueryResultsWithCallback,
that would be called with `*http.Response`,
so the caller could get at the raw response body.

However, doing this required either copying and modifying some code
(making the code worse), or doing a yak-shave to modify most
of the HTTP handling. Of course I went with the yak shave.

This rewrites all of the HTTP GET callers into a single method
which parameters are passed into. In theory the other HTTP verb
methods should also use this; but I didn't need to touch them,
so I left them for now.

So conceptually, instead of `httpGetJSON` and `httpGetJSONAndSend`
and all variations of content types and other specializations,
we just have something akin to
`newAuthedHttpInput(...) httpRequestInput` and
`makeHttpRequest(httpRequestInput)`. The callers are responsible
for configuring the http request input options appropriately.

Additionally, we have some different uses of the term
"content type." Specifically, for bulk work, it's the strings
"JSON", "CSV", and "XML", but elsewhere it's "application/json",
"text/csv", and "application/xml".
We introduce JobContentType and ContentType types to represent these,
and try to avoid using the string content type
(which is still on JobInfo since I didn't want to break
backwards compat).

Over the course of this refactor, I found a couple bugs:

- We were using `X-Sfdc-Session` as "Bearer: <token>" in some places,
  and as simply "<token>" in others.
- Rate limiting was only handled on some code paths, and not others.
- I am pretty sure some of the post/patch/etc methods call the
  wrong method for their retry; but things so happen to work anyway.
- One of the json bind variables was wrong

Because this was an entirely internal refactor,
I only added a test for the new method that takes the http callback.
This is also our first ghttp test in the repo,
so more should follow.

This one method fortunately covers a large part of the changes;
most of the rest are covered by the static typing.
But it warrants some further testing and a close review anyway.