### PR TITLE
Add an extensible HTTP request/response system (LP 62256235)

### DIFF
--- a/lib/auth.go
+++ b/lib/auth.go
@@ -13,11 +13,11 @@ import (
 
 func (f *Force) userInfo() (userinfo UserInfo, err error) {
 	url := fmt.Sprintf("%s/services/oauth2/userinfo", f.Credentials.InstanceUrl)
-	login, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	login, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal([]byte(login), &userinfo)
+	err = json.Unmarshal(login, &userinfo)
 	return
 }
 

--- a/lib/auth.go
+++ b/lib/auth.go
@@ -13,7 +13,7 @@ import (
 
 func (f *Force) userInfo() (userinfo UserInfo, err error) {
 	url := fmt.Sprintf("%s/services/oauth2/userinfo", f.Credentials.InstanceUrl)
-	login, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	login, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}

--- a/lib/bulk.go
+++ b/lib/bulk.go
@@ -129,20 +129,24 @@ func (f *Force) CloseBulkJob(jobId string) (result JobInfo, err error) {
 	return
 }
 
-func (f *Force) GetBulkJobs() (result []JobInfo, err error) {
+func (f *Force) GetBulkJobs() ([]JobInfo, error) {
 	url := fmt.Sprintf("%s/services/async/%s/jobs", f.Credentials.InstanceUrl, apiVersionNumber)
-	body, _, err := f.httpGetBulk(url)
-	xml.Unmarshal(body, &result)
+	resp, err := f.httpGetBulk(url)
+	if err != nil {
+		return nil, err
+	}
+	var result []JobInfo
+	xml.Unmarshal(resp.ReadResponseBody, &result)
 	if len(result[0].Id) == 0 {
 		var fault LoginFault
-		xml.Unmarshal(body, &fault)
+		xml.Unmarshal(resp.ReadResponseBody, &fault)
 		err = errors.New(fmt.Sprintf("%s: %s", fault.ExceptionCode, fault.ExceptionMessage))
 	}
-	return
+	return result, err
 }
 
-func (f *Force) httpGetBulk(url string) (body []byte, contentType ContentType, err error) {
-	return f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url).WithContent(ContentTypeXml))
+func (f *Force) httpGetBulk(url string) (*Response, error) {
+	return f.NewRequest("GET").AbsoluteUrl(url).WithContent(ContentTypeXml).ReadResponseBody().Execute()
 }
 
 func (f *Force) BulkQuery(soql string, jobId string, contentType string, requestOptions ...func(*http.Request)) (BatchInfo, error) {
@@ -236,62 +240,74 @@ func (f *Force) AddBatchToJob(content string, job JobInfo) (BatchInfo, error) {
 	}
 }
 
-func (f *Force) GetBatchInfo(jobId string, batchId string) (result BatchInfo, err error) {
+func (f *Force) GetBatchInfo(jobId string, batchId string) (BatchInfo, error) {
+	var result BatchInfo
 	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId)
-	body, contentType, err := f.httpGetBulk(url)
 
-	if contentType == ContentTypeJson {
-		json.Unmarshal(body, &result)
+	resp, err := f.httpGetBulk(url)
+	if err != nil {
+		return result, err
+	}
+
+	if resp.ContentType == ContentTypeJson {
+		json.Unmarshal(resp.ReadResponseBody, &result)
 		if len(result.Id) == 0 {
 			var fault LoginFault
-			json.Unmarshal(body, &fault)
+			json.Unmarshal(resp.ReadResponseBody, &fault)
 			err = errors.New(fmt.Sprintf("%s: %s", fault.ExceptionCode, fault.ExceptionMessage))
 		}
 	} else {
-		xml.Unmarshal(body, &result)
+		xml.Unmarshal(resp.ReadResponseBody, &result)
 		if len(result.Id) == 0 {
 			var fault LoginFault
-			xml.Unmarshal(body, &fault)
+			xml.Unmarshal(resp.ReadResponseBody, &fault)
 			err = errors.New(fmt.Sprintf("%s: %s", fault.ExceptionCode, fault.ExceptionMessage))
 		}
 	}
 
-	return
+	return result, err
 }
 
 func (f *Force) GetBatches(jobId string) (result []BatchInfo, err error) {
 	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
-	body, contentType, err := f.httpGetBulk(url)
+	resp, err := f.httpGetBulk(url)
+	if err != nil {
+		return nil, err
+	}
 
 	var batchInfoList struct {
 		BatchInfos []BatchInfo `xml:"batchInfo" json:"batchInfo"`
 	}
 
-	if contentType == ContentTypeJson {
-		json.Unmarshal(body, &batchInfoList)
+	if resp.ContentType == ContentTypeJson {
+		json.Unmarshal(resp.ReadResponseBody, &batchInfoList)
 		result = batchInfoList.BatchInfos
 	} else {
-		xml.Unmarshal(body, &batchInfoList)
+		xml.Unmarshal(resp.ReadResponseBody, &batchInfoList)
 		result = batchInfoList.BatchInfos
 		if len(result) == 0 {
 			var fault LoginFault
-			xml.Unmarshal(body, &fault)
+			xml.Unmarshal(resp.ReadResponseBody, &fault)
 			err = errors.New(fmt.Sprintf("%s: %s", fault.ExceptionCode, fault.ExceptionMessage))
 		}
 	}
 	return
 }
 
-func (f *Force) GetJobInfo(jobId string) (result JobInfo, err error) {
+func (f *Force) GetJobInfo(jobId string) (JobInfo, error) {
 	url := fmt.Sprintf("%s/services/async/%s/job/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId)
-	body, _, err := f.httpGetBulk(url)
-	xml.Unmarshal(body, &result)
+	resp, err := f.httpGetBulk(url)
+	if err != nil {
+		return JobInfo{}, err
+	}
+	var result JobInfo
+	xml.Unmarshal(resp.ReadResponseBody, &result)
 	if len(result.Id) == 0 {
 		var fault LoginFault
-		xml.Unmarshal(body, &fault)
+		xml.Unmarshal(resp.ReadResponseBody, &fault)
 		err = errors.New(fmt.Sprintf("%s: %s", fault.ExceptionCode, fault.ExceptionMessage))
 	}
-	return
+	return result, err
 }
 
 func (f *Force) RetrieveBulkQueryResultList(job JobInfo, batchId string) ([]byte, error) {
@@ -300,20 +316,26 @@ func (f *Force) RetrieveBulkQueryResultList(job JobInfo, batchId string) ([]byte
 	if err != nil {
 		return nil, err
 	}
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url).WithContent(ct))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url).WithContent(ct))
 	return body, err
 }
 
-func (f *Force) RetrieveBulkQuery(jobId string, batchId string) (result []byte, err error) {
+func (f *Force) RetrieveBulkQuery(jobId string, batchId string) ([]byte, error) {
 	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s/result", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId)
-	result, _, err = f.httpGetBulk(url)
-	return
+	resp, err := f.httpGetBulk(url)
+	if err != nil {
+		return nil, err
+	}
+	return resp.ReadResponseBody, nil
 }
 
-func (f *Force) RetrieveBulkQueryResults(jobId string, batchId string, resultId string) (result []byte, err error) {
+func (f *Force) RetrieveBulkQueryResults(jobId string, batchId string, resultId string) ([]byte, error) {
 	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s/result/%s", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId, resultId)
-	result, _, err = f.httpGetBulk(url)
-	return
+	resp, err := f.httpGetBulk(url)
+	if err != nil {
+		return nil, err
+	}
+	return resp.ReadResponseBody, nil
 }
 
 func (f *Force) RetrieveBulkJobQueryResults(job JobInfo, batchId string, resultId string) ([]byte, error) {
@@ -322,7 +344,7 @@ func (f *Force) RetrieveBulkJobQueryResults(job JobInfo, batchId string, resultI
 	if err != nil {
 		return nil, err
 	}
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url).WithContent(ct))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url).WithContent(ct))
 	return body, err
 }
 
@@ -332,7 +354,8 @@ func (f *Force) RetrieveBulkJobQueryResultsWithCallback(job JobInfo, batchId str
 	if err != nil {
 		return err
 	}
-	return f.makeHttpRequest(f.newAuthedHttpInput("GET", url).WithContent(ct).WithCallback(callback))
+	_, err = f.NewRequest("GET").AbsoluteUrl(url).WithContent(ct).WithResponseCallback(callback).Execute()
+	return err
 }
 
 // Deprecated: Use RetrieveBulkJobQueryResultsWithCallback
@@ -340,16 +363,9 @@ func (f *Force) RetrieveBulkJobQueryResultsAndSend(job JobInfo, batchId string, 
 	return f.RetrieveBulkJobQueryResultsWithCallback(job, batchId, resultId, NewBatchResultChannelHttpCallback(results, 0))
 }
 
-func (f *Force) RetrieveBulkBatchResults(jobId string, batchId string) (results BatchResult, err error) {
-	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch/%s/result", f.Credentials.InstanceUrl, apiVersionNumber, jobId, batchId)
-	result, _, err := f.httpGetBulk(url)
-	if len(result) == 0 {
-		var fault LoginFault
-		xml.Unmarshal(result, &fault)
-		err = errors.New(fmt.Sprintf("%s: %s", fault.ExceptionCode, fault.ExceptionMessage))
-	}
-	//	sreader = Reader.NewReader(result);
-	return
+func (f *Force) RetrieveBulkBatchResults(jobId string, batchId string) (BatchResult, error) {
+	err := errors.New("this method was never working right, please report an issue in GitHub if you were using it")
+	return BatchResult{}, err
 }
 
 // NewChannelChunkBatchResultsReporter returns a new reporter that will send chunks of a read body into

--- a/lib/bulk.go
+++ b/lib/bulk.go
@@ -146,7 +146,8 @@ func (f *Force) GetBulkJobs() ([]JobInfo, error) {
 }
 
 func (f *Force) httpGetBulk(url string) (*Response, error) {
-	return f.NewRequest("GET").AbsoluteUrl(url).WithContent(ContentTypeXml).ReadResponseBody().Execute()
+	req := NewRequest("GET").AbsoluteUrl(url).WithContent(ContentTypeXml).ReadResponseBody()
+	return f.ExecuteRequest(req)
 }
 
 func (f *Force) BulkQuery(soql string, jobId string, contentType string, requestOptions ...func(*http.Request)) (BatchInfo, error) {
@@ -316,7 +317,7 @@ func (f *Force) RetrieveBulkQueryResultList(job JobInfo, batchId string) ([]byte
 	if err != nil {
 		return nil, err
 	}
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url).WithContent(ct))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url).WithContent(ct))
 	return body, err
 }
 
@@ -344,7 +345,7 @@ func (f *Force) RetrieveBulkJobQueryResults(job JobInfo, batchId string, resultI
 	if err != nil {
 		return nil, err
 	}
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url).WithContent(ct))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url).WithContent(ct))
 	return body, err
 }
 
@@ -354,7 +355,8 @@ func (f *Force) RetrieveBulkJobQueryResultsWithCallback(job JobInfo, batchId str
 	if err != nil {
 		return err
 	}
-	_, err = f.NewRequest("GET").AbsoluteUrl(url).WithContent(ct).WithResponseCallback(callback).Execute()
+	req := NewRequest("GET").AbsoluteUrl(url).WithContent(ct).WithResponseCallback(callback)
+	_, err = f.ExecuteRequest(req)
 	return err
 }
 

--- a/lib/force.go
+++ b/lib/force.go
@@ -336,7 +336,7 @@ func ForceLoginAtEndpoint(endpoint string) (creds ForceSession, err error) {
 func (f *Force) GetCodeCoverage(classId string, className string) (err error) {
 	url := fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id+From+ApexClass+Where+Name+=+'%s'", f.Credentials.InstanceUrl, apiVersion, className)
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -350,7 +350,7 @@ func (f *Force) GetCodeCoverage(classId string, className string) (err error) {
 	classId = result.Records[0]["Id"].(string)
 	url = fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Coverage,+NumLinesCovered,+NumLinesUncovered,+ApexTestClassId,+ApexClassorTriggerId+From+ApexCodeCoverage+Where+ApexClassorTriggerId='%s'", f.Credentials.InstanceUrl, apiVersion, classId)
 
-	body, err = f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err = f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -431,7 +431,7 @@ func (f *Force) QueryDataPipeline(soql string) (results ForceQueryResult, err er
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(soql))
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -445,7 +445,7 @@ func (f *Force) QueryDataPipelineJob(soql string) (results ForceQueryResult, err
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(soql))
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -465,7 +465,7 @@ func (f *Force) GetAuraBundleDefinitions() (definitions AuraDefinitionBundleResu
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape("SELECT Id, Source, AuraDefinitionBundleId, DefType, Format FROM AuraDefinition"))
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -488,7 +488,7 @@ func (f *Force) GetMoreAuraBundleDefinitions(definitions *AuraDefinitionBundleRe
 		moreDefs := new(AuraDefinitionBundleResult)
 		aurl := fmt.Sprintf("%s%s", f.Credentials.InstanceUrl, nextRecordsUrl)
 
-		body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+		body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 		if err != nil {
 			return err
 		}
@@ -510,7 +510,7 @@ func (f *Force) GetMoreAuraBundleDefinitions(definitions *AuraDefinitionBundleRe
 func (f *Force) GetAuraBundlesList() (bundles AuraDefinitionBundleResult, err error) {
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape("SELECT Id, DeveloperName, NamespacePrefix, ApiVersion, Description FROM AuraDefinitionBundle"))
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -535,7 +535,7 @@ func (f *Force) GetAuraBundleByName(bundleName string) (bundles AuraDefinitionBu
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(fmt.Sprintf("SELECT Id, DeveloperName, NamespacePrefix, ApiVersion, Description FROM AuraDefinitionBundle%s", criteria)))
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -548,7 +548,7 @@ func (f *Force) GetAuraBundleDefinition(id string) (definitions AuraDefinitionBu
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(fmt.Sprintf("SELECT Id, Source, AuraDefinitionBundleId, DefType, Format FROM AuraDefinition WHERE AuraDefinitionBundleId = '%s'", id)))
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -586,7 +586,7 @@ func (f *Force) CreateAuraComponent(attrs map[string]string) (result ForceCreate
 
 func (f *Force) ListSobjects() (sobjects []ForceSobject, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects", f.Credentials.InstanceUrl, apiVersion)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -598,7 +598,7 @@ func (f *Force) ListSobjects() (sobjects []ForceSobject, err error) {
 
 func (f *Force) GetSobject(name string) (sobject ForceSobject, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/%s/describe", f.Credentials.InstanceUrl, apiVersion, name)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -641,7 +641,7 @@ func (f *Force) Query(qs string, options ...func(*QueryOptions)) (ForceQueryResu
 func (f *Force) QueryOptions() []query.Option {
 	return []query.Option{
 		query.HttpGet(func(url string) ([]byte, error) {
-			body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+			body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 			return body, err
 		}),
 		query.InstanceUrl(f.Credentials.InstanceUrl),
@@ -667,7 +667,7 @@ func (f *Force) legacyQueryOptions(qs string, options ...func(*QueryOptions)) []
 }
 
 func (f *Force) Get(url string) (object ForceRecord, err error) {
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -678,7 +678,7 @@ func (f *Force) Get(url string) (object ForceRecord, err error) {
 func (f *Force) GetLimits() (result map[string]ForceLimit, err error) {
 
 	url := fmt.Sprintf("%s/services/data/%s/limits", f.Credentials.InstanceUrl, apiVersion)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -689,7 +689,7 @@ func (f *Force) GetLimits() (result map[string]ForceLimit, err error) {
 
 func (f *Force) GetPasswordStatus(id string) (result ForcePasswordStatusResult, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/User/%s/password", f.Credentials.InstanceUrl, apiVersion, id)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -722,7 +722,7 @@ func (f *Force) GetRecord(sobject, id string) (object ForceRecord, err error) {
 		url = fmt.Sprintf("%s/services/data/%s/sobjects/%s/%s/%s", f.Credentials.InstanceUrl, apiVersion, sobject, fields[0], fields[1])
 	}
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -753,7 +753,7 @@ func (f *Force) QueryProfile(fields ...string) (results ForceQueryResult, err er
 		strings.Join(fields, ","),
 		f.Credentials.UserInfo.ProfileId)
 
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -763,7 +763,7 @@ func (f *Force) QueryProfile(fields ...string) (results ForceQueryResult, err er
 
 func (f *Force) QueryTraceFlags() (results ForceQueryResult, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Id,+DebugLevel.DeveloperName,++ApexCode,+ApexProfiling,+Callout,+CreatedDate,+Database,+ExpirationDate,+System,+TracedEntity.Name,+Validation,+Visualforce,+Workflow+From+TraceFlag+Order+By+ExpirationDate,TracedEntity.Name", f.Credentials.InstanceUrl, apiVersion)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -773,7 +773,7 @@ func (f *Force) QueryTraceFlags() (results ForceQueryResult, err error) {
 
 func (f *Force) QueryDefaultDebugLevel() (id string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Id+From+DebugLevel+Where+DeveloperName+=+'Force_CLI'", f.Credentials.InstanceUrl, apiVersion)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -847,14 +847,14 @@ func (f *Force) StartTrace(userId ...string) (result ForceCreateRecordResult, er
 
 func (f *Force) RetrieveLog(logId string) (result string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/sobjects/ApexLog/%s/Body", f.Credentials.InstanceUrl, apiVersion, logId)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	result = string(body)
 	return
 }
 
 func (f *Force) QueryLogs() (results ForceQueryResult, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Id,+Application,+DurationMilliseconds,+Location,+LogLength,+LogUser.Name,+Operation,+Request,StartTime,+Status+From+ApexLog+Order+By+StartTime", f.Credentials.InstanceUrl, apiVersion)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -864,7 +864,7 @@ func (f *Force) QueryLogs() (results ForceQueryResult, err error) {
 
 func (f *Force) RetrieveEventLogFile(elfId string) (result string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/EventLogFile/%s/LogFile", f.Credentials.InstanceUrl, apiVersion, elfId)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -900,7 +900,7 @@ func (f *Force) QueryEventLogFiles() (results ForceQueryResult, err error) {
 	} else {
 		url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
 	}
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -934,7 +934,7 @@ func (f *Force) CreateToolingRecord(objecttype string, attrs map[string]string) 
 
 func (f *Force) DescribeSObject(objecttype string) (result string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/%s/describe", f.Credentials.InstanceUrl, apiVersion, objecttype)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -965,27 +965,13 @@ func (f *Force) Whoami() (me ForceRecord, err error) {
 	return
 }
 
-// Prepend /services/data/vXX.0 to URL
-func (f *Force) fullRestUrl(url string) string {
-	return fmt.Sprintf("/services/data/%s/%s", apiVersion, strings.TrimLeft(url, "/"))
-}
-
 // Prepend https schema and instance to URL
 func (f *Force) qualifyUrl(url string) string {
 	return fmt.Sprintf("%s/%s", f.Credentials.InstanceUrl, strings.TrimLeft(url, "/"))
 }
 
 func (f *Force) GetAbsoluteBytes(url string) (result []byte, err error) {
-	qualifiedUrl := f.qualifyUrl(url)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(qualifiedUrl))
-	if err == SessionExpiredError {
-		err = f.RefreshSession()
-		if err != nil {
-			return
-		}
-		return f.GetAbsoluteBytes(url)
-	}
-	return body, err
+	return f.makeHttpRequestSync(NewRequest("GET").RootUrl(url))
 }
 
 func (f *Force) GetAbsolute(url string) (string, error) {
@@ -997,8 +983,8 @@ func (f *Force) GetAbsolute(url string) (string, error) {
 }
 
 func (f *Force) GetREST(url string) (result string, err error) {
-	fullUrl := f.fullRestUrl(url)
-	return f.GetAbsolute(fullUrl)
+	body, err := f.makeHttpRequestSync(NewRequest("GET").RestUrl(url))
+	return string(body), err
 }
 
 func (f *Force) PostPatchAbsolute(url string, content string, method string) (result string, err error) {
@@ -1032,7 +1018,7 @@ func (f *Force) PostAbsolute(url string, content string) (result string, err err
 }
 
 func (f *Force) PostREST(url string, content string) (result string, err error) {
-	fullUrl := f.fullRestUrl(url)
+	fullUrl := fullRestUrl(url)
 	return f.PostAbsolute(fullUrl, content)
 }
 
@@ -1051,13 +1037,13 @@ func (f *Force) PatchAbsolute(url string, content string) (result string, err er
 }
 
 func (f *Force) PatchREST(url string, content string) (result string, err error) {
-	fullUrl := f.fullRestUrl(url)
+	fullUrl := fullRestUrl(url)
 	return f.PatchAbsolute(fullUrl, content)
 }
 
 func (f *Force) getForceResult(url string) (results ForceQueryResult, err error) {
 	furl := fmt.Sprintf("%s%s", f.Credentials.InstanceUrl, url)
-	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(furl))
+	body, err := f.makeHttpRequestSync(NewRequest("GET").AbsoluteUrl(furl))
 	if err != nil {
 		return
 	}
@@ -1073,7 +1059,7 @@ func (f *Force) setHttpInputAuth(input *httpRequestInput) *httpRequestInput {
 
 func (f *Force) makeHttpRequestSync(req *Request) (body []byte, err error) {
 	req = req.ReadResponseBody()
-	resp, err := req.Execute()
+	resp, err := f.ExecuteRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/force.go
+++ b/lib/force.go
@@ -336,7 +336,7 @@ func ForceLoginAtEndpoint(endpoint string) (creds ForceSession, err error) {
 func (f *Force) GetCodeCoverage(classId string, className string) (err error) {
 	url := fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id+From+ApexClass+Where+Name+=+'%s'", f.Credentials.InstanceUrl, apiVersion, className)
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -350,7 +350,7 @@ func (f *Force) GetCodeCoverage(classId string, className string) (err error) {
 	classId = result.Records[0]["Id"].(string)
 	url = fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Coverage,+NumLinesCovered,+NumLinesUncovered,+ApexTestClassId,+ApexClassorTriggerId+From+ApexCodeCoverage+Where+ApexClassorTriggerId='%s'", f.Credentials.InstanceUrl, apiVersion, classId)
 
-	body, _, err = f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err = f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -431,7 +431,7 @@ func (f *Force) QueryDataPipeline(soql string) (results ForceQueryResult, err er
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(soql))
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -445,7 +445,7 @@ func (f *Force) QueryDataPipelineJob(soql string) (results ForceQueryResult, err
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(soql))
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -465,7 +465,7 @@ func (f *Force) GetAuraBundleDefinitions() (definitions AuraDefinitionBundleResu
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape("SELECT Id, Source, AuraDefinitionBundleId, DefType, Format FROM AuraDefinition"))
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -488,7 +488,7 @@ func (f *Force) GetMoreAuraBundleDefinitions(definitions *AuraDefinitionBundleRe
 		moreDefs := new(AuraDefinitionBundleResult)
 		aurl := fmt.Sprintf("%s%s", f.Credentials.InstanceUrl, nextRecordsUrl)
 
-		body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+		body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 		if err != nil {
 			return err
 		}
@@ -510,7 +510,7 @@ func (f *Force) GetMoreAuraBundleDefinitions(definitions *AuraDefinitionBundleRe
 func (f *Force) GetAuraBundlesList() (bundles AuraDefinitionBundleResult, err error) {
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape("SELECT Id, DeveloperName, NamespacePrefix, ApiVersion, Description FROM AuraDefinitionBundle"))
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -535,7 +535,7 @@ func (f *Force) GetAuraBundleByName(bundleName string) (bundles AuraDefinitionBu
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(fmt.Sprintf("SELECT Id, DeveloperName, NamespacePrefix, ApiVersion, Description FROM AuraDefinitionBundle%s", criteria)))
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -548,7 +548,7 @@ func (f *Force) GetAuraBundleDefinition(id string) (definitions AuraDefinitionBu
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
 		url.QueryEscape(fmt.Sprintf("SELECT Id, Source, AuraDefinitionBundleId, DefType, Format FROM AuraDefinition WHERE AuraDefinitionBundleId = '%s'", id)))
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", aurl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(aurl))
 	if err != nil {
 		return
 	}
@@ -586,7 +586,7 @@ func (f *Force) CreateAuraComponent(attrs map[string]string) (result ForceCreate
 
 func (f *Force) ListSobjects() (sobjects []ForceSobject, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects", f.Credentials.InstanceUrl, apiVersion)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -598,7 +598,7 @@ func (f *Force) ListSobjects() (sobjects []ForceSobject, err error) {
 
 func (f *Force) GetSobject(name string) (sobject ForceSobject, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/%s/describe", f.Credentials.InstanceUrl, apiVersion, name)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -641,7 +641,7 @@ func (f *Force) Query(qs string, options ...func(*QueryOptions)) (ForceQueryResu
 func (f *Force) QueryOptions() []query.Option {
 	return []query.Option{
 		query.HttpGet(func(url string) ([]byte, error) {
-			body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+			body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 			return body, err
 		}),
 		query.InstanceUrl(f.Credentials.InstanceUrl),
@@ -667,7 +667,7 @@ func (f *Force) legacyQueryOptions(qs string, options ...func(*QueryOptions)) []
 }
 
 func (f *Force) Get(url string) (object ForceRecord, err error) {
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -678,7 +678,7 @@ func (f *Force) Get(url string) (object ForceRecord, err error) {
 func (f *Force) GetLimits() (result map[string]ForceLimit, err error) {
 
 	url := fmt.Sprintf("%s/services/data/%s/limits", f.Credentials.InstanceUrl, apiVersion)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -689,7 +689,7 @@ func (f *Force) GetLimits() (result map[string]ForceLimit, err error) {
 
 func (f *Force) GetPasswordStatus(id string) (result ForcePasswordStatusResult, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/User/%s/password", f.Credentials.InstanceUrl, apiVersion, id)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -722,7 +722,7 @@ func (f *Force) GetRecord(sobject, id string) (object ForceRecord, err error) {
 		url = fmt.Sprintf("%s/services/data/%s/sobjects/%s/%s/%s", f.Credentials.InstanceUrl, apiVersion, sobject, fields[0], fields[1])
 	}
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -753,7 +753,7 @@ func (f *Force) QueryProfile(fields ...string) (results ForceQueryResult, err er
 		strings.Join(fields, ","),
 		f.Credentials.UserInfo.ProfileId)
 
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -763,7 +763,7 @@ func (f *Force) QueryProfile(fields ...string) (results ForceQueryResult, err er
 
 func (f *Force) QueryTraceFlags() (results ForceQueryResult, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Id,+DebugLevel.DeveloperName,++ApexCode,+ApexProfiling,+Callout,+CreatedDate,+Database,+ExpirationDate,+System,+TracedEntity.Name,+Validation,+Visualforce,+Workflow+From+TraceFlag+Order+By+ExpirationDate,TracedEntity.Name", f.Credentials.InstanceUrl, apiVersion)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -773,7 +773,7 @@ func (f *Force) QueryTraceFlags() (results ForceQueryResult, err error) {
 
 func (f *Force) QueryDefaultDebugLevel() (id string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Id+From+DebugLevel+Where+DeveloperName+=+'Force_CLI'", f.Credentials.InstanceUrl, apiVersion)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -847,14 +847,14 @@ func (f *Force) StartTrace(userId ...string) (result ForceCreateRecordResult, er
 
 func (f *Force) RetrieveLog(logId string) (result string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/sobjects/ApexLog/%s/Body", f.Credentials.InstanceUrl, apiVersion, logId)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	result = string(body)
 	return
 }
 
 func (f *Force) QueryLogs() (results ForceQueryResult, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/query/?q=Select+Id,+Application,+DurationMilliseconds,+Location,+LogLength,+LogUser.Name,+Operation,+Request,StartTime,+Status+From+ApexLog+Order+By+StartTime", f.Credentials.InstanceUrl, apiVersion)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -864,7 +864,7 @@ func (f *Force) QueryLogs() (results ForceQueryResult, err error) {
 
 func (f *Force) RetrieveEventLogFile(elfId string) (result string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/EventLogFile/%s/LogFile", f.Credentials.InstanceUrl, apiVersion, elfId)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -900,7 +900,7 @@ func (f *Force) QueryEventLogFiles() (results ForceQueryResult, err error) {
 	} else {
 		url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
 	}
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -934,7 +934,7 @@ func (f *Force) CreateToolingRecord(objecttype string, attrs map[string]string) 
 
 func (f *Force) DescribeSObject(objecttype string) (result string, err error) {
 	url := fmt.Sprintf("%s/services/data/%s/sobjects/%s/describe", f.Credentials.InstanceUrl, apiVersion, objecttype)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", url))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(url))
 	if err != nil {
 		return
 	}
@@ -977,7 +977,7 @@ func (f *Force) qualifyUrl(url string) string {
 
 func (f *Force) GetAbsoluteBytes(url string) (result []byte, err error) {
 	qualifiedUrl := f.qualifyUrl(url)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", qualifiedUrl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(qualifiedUrl))
 	if err == SessionExpiredError {
 		err = f.RefreshSession()
 		if err != nil {
@@ -1057,22 +1057,12 @@ func (f *Force) PatchREST(url string, content string) (result string, err error)
 
 func (f *Force) getForceResult(url string) (results ForceQueryResult, err error) {
 	furl := fmt.Sprintf("%s%s", f.Credentials.InstanceUrl, url)
-	body, _, err := f.makeHttpRequestSync(f.newAuthedHttpInput("GET", furl))
+	body, err := f.makeHttpRequestSync(f.NewRequest("GET").AbsoluteUrl(furl))
 	if err != nil {
 		return
 	}
 	json.Unmarshal(body, &results)
 	return
-}
-
-func (f *Force) newAuthedHttpInput(method, url string) *httpRequestInput {
-	inp := &httpRequestInput{
-		Method:  method,
-		Url:     url,
-		Headers: map[string]string{},
-		Retrier: (&httpRetrier{}).Reauth(),
-	}
-	return f.setHttpInputAuth(inp)
 }
 
 func (f *Force) setHttpInputAuth(input *httpRequestInput) *httpRequestInput {
@@ -1081,15 +1071,13 @@ func (f *Force) setHttpInputAuth(input *httpRequestInput) *httpRequestInput {
 	return input
 }
 
-func (f *Force) makeHttpRequestSync(input *httpRequestInput) (body []byte, contentType ContentType, err error) {
-	input.Callback = func(r *http.Response) error {
-		contentType = ContentType(r.Header.Get("Content-Type"))
-		body, err = ioutil.ReadAll(r.Body)
-		r.Body.Close()
-		return err
+func (f *Force) makeHttpRequestSync(req *Request) (body []byte, err error) {
+	req = req.ReadResponseBody()
+	resp, err := req.Execute()
+	if err != nil {
+		return nil, err
 	}
-	err = f.makeHttpRequest(input)
-	return
+	return resp.ReadResponseBody, nil
 }
 
 func (f *Force) makeHttpRequest(input *httpRequestInput) error {

--- a/lib/request.go
+++ b/lib/request.go
@@ -1,0 +1,145 @@
+package lib
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// Request configures a Salesforce API request.
+// Use Force.NewRequest to create a new request.
+//
+// By default, Force does not process the HTTP response body in the case of success
+// (it may parse it in the case of an error). In this case, you are responsible
+// for closing (and optionally reading) the response body.
+//
+// If you want the body to be read synchronously, use ReadResponseBody().
+// You should not use Response.HttpResponse's Body in this case.
+type Request struct {
+	f                *Force
+	method           string
+	fullUrl          string
+	Headers          map[string]string
+	body             io.Reader
+	readResponseBody bool
+	callback         HttpCallback
+	unauthed         bool
+}
+
+// Response is the result of a Salesforce API call.
+type Response struct {
+	// If Request.ReadResponseBody is used,
+	// the HTTP response body is read into Response.ReadResponseBody.
+	// This covers a common use case where the caller wants
+	// to read the entire body synchronously,
+	// rather than having to worry about managing the stream.
+	ReadResponseBody []byte
+	// The raw http.Response returned by the HTTP request.
+	HttpResponse *http.Response
+	// The coerced ContentType from the Content-Type header.
+	ContentType ContentType
+}
+
+func (f *Force) NewRequest(httpMethod string) *Request {
+	return &Request{f: f, method: httpMethod, Headers: map[string]string{}}
+}
+
+// RestUrl is used when the url specifies the "Apex REST" portion of the url.
+// For example, the url of "/MyApexRestClass" would use a full URL of
+// https://me.salesforce.com/services/data/41.0/MyApexRESTClass.
+func (r *Request) RestUrl(url string) *Request {
+	return r.AbsoluteUrl(r.f.fullRestUrl(url))
+}
+
+// RestUrl is used when the url specifies the root-based relative URL of a resource.
+// For example, the url of "/services/async/42.0/job" would use a full URL of
+// https://me.salesforce.com/services/async/42.0/job.
+func (r *Request) RootUrl(url string) *Request {
+	return r.AbsoluteUrl(r.f.qualifyUrl(url))
+}
+
+// AbsoluteUrl is used when the url specifies the absolute url,
+// such as "https://me.salesforce.com/services/async/42.0/job".
+func (r *Request) AbsoluteUrl(url string) *Request {
+	r.fullUrl = url
+	return r
+}
+
+// WithHeader sets the given header.
+func (r *Request) WithHeader(k, v string) *Request {
+	r.Headers[k] = v
+	return r
+}
+
+// WithContent sets the Content-Type header.
+func (r *Request) WithContent(ct ContentType) *Request {
+	return r.WithHeader("Content-Type", string(ct))
+}
+
+// WithBody sets the HTTP request body.
+func (r *Request) WithBody(rdr io.Reader) *Request {
+	r.body = rdr
+	return r
+}
+
+// ReadResponseBody specifies that the request should read and close
+// the response body. Use when you want a synchronous read of the response.
+// Be careful with large response bodies.
+func (r *Request) ReadResponseBody() *Request {
+	r.readResponseBody = true
+	return r
+}
+
+// WithResponseCallback specifies a callback invoked with the *http.Response of a request.
+// Most callers will not need this when invoking Request.Execute directly,
+// since they have access to the *http.Response from the Response.
+// However when a method does not deal with Request and Response,
+// WithResponseCallback can be useful to allow access to the response,
+// usually to access the HTTP response body stream.
+func (r *Request) WithResponseCallback(cb HttpCallback) *Request {
+	r.callback = cb
+	return r
+}
+
+// Unauthed will send the request without authentication headers.
+func (r *Request) Unauthed() *Request {
+	r.unauthed = true
+	return r
+}
+
+// Execute executes an HTTP request based on Request,
+// processes the HTTP response in the configured way,
+// and returns the Force Response.
+//
+// Execute will retry once on a SessionExpired error
+// (future versions may allow configurable retry behavior).
+func (r *Request) Execute() (*Response, error) {
+	reqResp := &Response{}
+	inp := &httpRequestInput{
+		Method:  r.method,
+		Url:     r.fullUrl,
+		Headers: r.Headers,
+		Callback: func(resp *http.Response) error {
+			reqResp.HttpResponse = resp
+			reqResp.ContentType = ContentType(resp.Header.Get("Content-Type"))
+			if r.readResponseBody {
+				b, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
+				resp.Body.Close()
+				reqResp.ReadResponseBody = b
+			} else if r.callback != nil {
+				return r.callback(resp)
+			}
+			return nil
+		},
+		Retrier: (&httpRetrier{}).Reauth(),
+		Body:    r.body,
+	}
+	if !r.unauthed {
+		r.f.setHttpInputAuth(inp)
+	}
+	err := r.f.makeHttpRequest(inp)
+	return reqResp, err
+}


### PR DESCRIPTION
In #598, support for an `HttpCallback` was added to some methods,
which gave callers access to the raw `*http.Response` for things like streaming in the body.

This was only added for POST/PUT/PATCH, because it used separate codepaths to GET requests.

This takes things a step further, and adds a configurable `lib.Request` and `lib.Response` type
that can be used by callers. See `request.go` for more details.

Notes:

- `Force.ExecuteRequest` is used (rather than `Request.Execute` so side-effects are on the `Force` class and callers can work with raw Request/Response objects.
- Most of the internal HTTP code written previously is not touched; the new Request/Response code is implemented in terms of that. That seemed safer since some of that (retry, etc) is pretty nuanced.
- No backwards incompatible changes, so the nesting-doll style calls like GetREST->GetAbsolute->GetAbsoluteBytes, etc., remain. However, the implementation is not more direct, with those methods configuring `Request` more directly.

Co-authored with @natalithic