### PR TITLE
Send Client In CallOptions

### DIFF
--- a/lib/force.go
+++ b/lib/force.go
@@ -50,6 +50,7 @@ const (
 type RefreshMethod int
 
 type Force struct {
+	ClientName  string
 	Credentials *ForceSession
 	Metadata    *ForceMetadata
 	Partner     *ForcePartner
@@ -243,6 +244,7 @@ type BundleManifest struct {
 
 func NewForce(creds *ForceSession) (force *Force) {
 	force = new(Force)
+	force.ClientName = "ForceCLI/" + Version
 	force.Credentials = creds
 	force.Metadata = NewForceMetadata(force)
 	force.Partner = NewForcePartner(force)
@@ -1178,6 +1180,7 @@ func (f *Force) httpPostPatch(url string, rbody string, contenttype ContentType,
 
 	req.Header.Add("X-SFDC-Session", f.Credentials.AccessToken)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
+	req.Header.Add("Sforce-Call-Options", fmt.Sprintf("client=%s;", f.ClientName))
 	req.Header.Add("Content-Type", string(contenttype))
 	res, err := doRequest(req)
 	if err != nil {
@@ -1220,6 +1223,7 @@ func (f *Force) httpPostAttributes(url string, attrs map[string]string) (body []
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Sforce-Call-Options", fmt.Sprintf("client=%s;", f.ClientName))
 	res, err := doRequest(req)
 	if err != nil {
 		return
@@ -1260,6 +1264,7 @@ func (f *Force) httpPatchAttributes(url string, attrs map[string]string) (body [
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Sforce-Call-Options", fmt.Sprintf("client=%s;", f.ClientName))
 	res, err := doRequest(req)
 	if err != nil {
 		return
@@ -1297,6 +1302,7 @@ func (f *Force) httpDeleteUrl(url string) (body []byte, err error) {
 		return
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
+	req.Header.Add("Sforce-Call-Options", fmt.Sprintf("client=%s;", f.ClientName))
 	res, err := doRequest(req)
 	if err != nil {
 		return

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -1462,7 +1462,7 @@ func (fm *ForceMetadata) ListConnectedApps() (apps ForceConnectedApps, err error
 
 func (fm *ForceMetadata) soapExecute(action, query string) (response []byte, err error) {
 	url := fmt.Sprintf("%s/services/Soap/m/%s", fm.Force.Credentials.InstanceUrl, fm.ApiVersion)
-	soap := NewSoap(url, "http://soap.sforce.com/2006/04/metadata", fm.Force.Credentials.AccessToken)
+	soap := NewSoap(url, "http://soap.sforce.com/2006/04/metadata", fm.Force.Credentials.AccessToken).WithClient(fm.Force.ClientName)
 	response, err = soap.Execute(action, query)
 	if err == SessionExpiredError {
 		err = fm.Force.RefreshSession()

--- a/lib/partner.go
+++ b/lib/partner.go
@@ -106,7 +106,7 @@ func (partner *ForcePartner) ExecuteAnonymousTest(apex string) (output string, e
 
 func (partner *ForcePartner) SoapExecuteCore(action, query string) (response []byte, err error) {
 	url := fmt.Sprintf("%s/services/Soap/u/%s/%s", partner.Force.Credentials.InstanceUrl, partner.Force.Credentials.SessionOptions.ApiVersion, partner.Force.Credentials.UserInfo.OrgId)
-	soap := NewSoap(url, "urn:partner.soap.sforce.com", partner.Force.Credentials.AccessToken)
+	soap := NewSoap(url, "urn:partner.soap.sforce.com", partner.Force.Credentials.AccessToken).WithClient(partner.Force.ClientName)
 	soap.Header = "<apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>"
 	response, err = soap.Execute(action, query)
 	if err == SessionExpiredError {
@@ -118,7 +118,7 @@ func (partner *ForcePartner) SoapExecuteCore(action, query string) (response []b
 
 func (partner *ForcePartner) soapExecute(action, query string) (response []byte, err error) {
 	url := fmt.Sprintf("%s/services/Soap/s/%s/%s", partner.Force.Credentials.InstanceUrl, partner.Force.Credentials.SessionOptions.ApiVersion, partner.Force.Credentials.UserInfo.OrgId)
-	soap := NewSoap(url, "http://soap.sforce.com/2006/08/apex", partner.Force.Credentials.AccessToken)
+	soap := NewSoap(url, "http://soap.sforce.com/2006/08/apex", partner.Force.Credentials.AccessToken).WithClient(partner.Force.ClientName)
 	soap.Header = "<apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>"
 	response, err = soap.Execute(action, query)
 	if err == SessionExpiredError {

--- a/lib/request.go
+++ b/lib/request.go
@@ -79,6 +79,11 @@ func (r *Request) WithContent(ct ContentType) *Request {
 	return r.WithHeader("Content-Type", string(ct))
 }
 
+// WithClient sets the Sforce-Call-Options header with client name
+func (r *Request) WithClient(clientName string) *Request {
+	return r.WithHeader("Sforce-Call-Options", fmt.Sprintf("client=%s;", clientName))
+}
+
 // WithBody sets the HTTP request body.
 func (r *Request) WithBody(rdr io.Reader) *Request {
 	r.body = rdr
@@ -140,6 +145,9 @@ func (f *Force) ExecuteRequest(r *Request) (*Response, error) {
 		absUrl = r.absoluteUrl
 	} else {
 		absUrl = f.qualifyUrl(r.rootedUrl)
+	}
+	if _, ok := r.Headers["Sforce-Call-Options"]; !ok {
+		r = r.WithClient(f.ClientName)
 	}
 	reqResp := &Response{}
 	inp := &httpRequestInput{

--- a/lib/soap.go
+++ b/lib/soap.go
@@ -19,6 +19,7 @@ type Soap struct {
 	Endpoint    string
 	Header      string
 	Namespace   string
+	ClientName  string
 }
 
 func NewSoap(endpoint, namespace, accessToken string) (s *Soap) {
@@ -28,6 +29,12 @@ func NewSoap(endpoint, namespace, accessToken string) (s *Soap) {
 	s.Endpoint = endpoint
 	return
 }
+
+func (s *Soap) WithClient(clientName string) *Soap {
+	s.ClientName = clientName
+	return s
+}
+
 func (s *Soap) ExecuteLogin(username, password string) (response []byte, err error) {
 	type SoapLogin struct {
 		XMLName  xml.Name `xml:"soapenv:Envelope"`
@@ -85,6 +92,9 @@ func (s *Soap) Execute(action, query string) (response []byte, err error) {
 				<cmd:SessionHeader>
 					<cmd:sessionId>%s</cmd:sessionId>
 				</cmd:SessionHeader>
+				<cmd:CallOptions>
+					<cmd:client>%s</cmd:client>
+				</cmd:CallOptions>
 				%s
 			</env:Header>
 			<env:Body>
@@ -95,7 +105,7 @@ func (s *Soap) Execute(action, query string) (response []byte, err error) {
 		</env:Envelope>
 	`
 	rbody := fmt.Sprintf(soap, s.Namespace,
-		s.AccessToken, s.Header, action, s.Namespace, query, action)
+		s.AccessToken, s.ClientName, s.Header, action, s.Namespace, query, action)
 	req, err := httpRequest("POST", s.Endpoint, strings.NewReader(rbody))
 	if err != nil {
 		return


### PR DESCRIPTION
Send client name in CallOptions SOAP header or Sforce-Call-Options
header so it's set in API Event Logs.