### PR TITLE
Add SessionOptions.RefreshFunc (LP 65463346)

### DIFF
--- a/lib/auth.go
+++ b/lib/auth.go
@@ -142,12 +142,18 @@ func ForceLoginAtEndpointAndSave(endpoint string, output *os.File) (username str
 	return
 }
 
+// UpdateCredentials calls CopyCredentialAuthFields and persists the new credentials in config.
 func (f *Force) UpdateCredentials(creds ForceSession) {
+	f.CopyCredentialAuthFields(&creds)
+	ForceSaveLogin(*f.Credentials, os.Stderr)
+}
+
+// CopyCredentialAuthFields copies auth fields from creds into the receiver's Credentials.
+func (f *Force) CopyCredentialAuthFields(creds *ForceSession) {
 	f.Credentials.AccessToken = creds.AccessToken
 	f.Credentials.IssuedAt = creds.IssuedAt
 	f.Credentials.InstanceUrl = creds.InstanceUrl
 	f.Credentials.Scope = creds.Scope
-	ForceSaveLogin(*f.Credentials, os.Stderr)
 }
 
 func ActiveForce() (force *Force, err error) {

--- a/lib/session.go
+++ b/lib/session.go
@@ -70,13 +70,13 @@ func (f *Force) RefreshSessionOrExit() {
 	}
 }
 
-func (f *Force) RefreshSession() (err error) {
-	if f.Credentials.SessionOptions.RefreshMethod == RefreshOauth {
-		err = f.refreshOauth()
+func (f *Force) RefreshSession() error {
+	if f.Credentials.SessionOptions.RefreshFunc != nil {
+		return f.Credentials.SessionOptions.RefreshFunc(f)
+	} else if f.Credentials.SessionOptions.RefreshMethod == RefreshOauth {
+		return f.refreshOauth()
 	} else if f.Credentials.SessionOptions.RefreshMethod == RefreshSFDX {
-		err = f.refreshSFDX()
-	} else {
-		err = SessionRefreshUnavailable
+		return f.refreshSFDX()
 	}
-	return
+	return SessionRefreshUnavailable
 }


### PR DESCRIPTION
Allows us to provide custom session refresh behavior,
so we can refresh JWT auth, and customize it further
in the future.