### PR TITLE
Handle Non-Standard JSON Error Responses

### DIFF
--- a/lib/force.go
+++ b/lib/force.go
@@ -1153,7 +1153,10 @@ func (f *Force) _coerceHttpError(res *http.Response, body []byte) error {
 	} else {
 		var errors ForceErrors
 		if err := internal.JsonUnmarshal(body, &errors); err != nil && !sessionExpired {
-			return err
+			var errors map[string]interface{}
+			if err := internal.JsonUnmarshal(body, &errors); err != nil {
+				return err
+			}
 		}
 		if len(errors) > 0 && errors[0].ErrorCode == "REQUEST_LIMIT_EXCEEDED" {
 			return APILimitExceededError

--- a/lib/force.go
+++ b/lib/force.go
@@ -1153,10 +1153,7 @@ func (f *Force) _coerceHttpError(res *http.Response, body []byte) error {
 	} else {
 		var errors ForceErrors
 		if err := internal.JsonUnmarshal(body, &errors); err != nil && !sessionExpired {
-			var errors map[string]interface{}
-			if err := internal.JsonUnmarshal(body, &errors); err != nil {
-				return err
-			}
+			return fmt.Errorf("unhandled error: %d %s", res.StatusCode, string(body))
 		}
 		if len(errors) > 0 && errors[0].ErrorCode == "REQUEST_LIMIT_EXCEEDED" {
 			return APILimitExceededError


### PR DESCRIPTION
If JSON errors can't be parsed into ForceErrors, parse as
map[string]interface{}.

Fixes returning errors when calling custom Apex REST endpoint and
receiving an error response that doesn't the shape of standard
Salesforce API errors.
