### PR TITLE
Add Global --apiversion Flag; Add `apiversion list` Command

### DIFF
--- a/command/apiversion.go
+++ b/command/apiversion.go
@@ -1,13 +1,20 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
-	"regexp"
 
 	. "github.com/ForceCLI/force/error"
 	. "github.com/ForceCLI/force/lib"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	apiVersionListCmd.Flags().BoolP("json", "j", false, "json output")
+	apiVersionCmd.AddCommand(apiVersionListCmd)
+
+	RootCmd.AddCommand(apiVersionCmd)
+}
 
 var apiVersionCmd = &cobra.Command{
 	Use:   "apiversion",
@@ -15,6 +22,7 @@ var apiVersionCmd = &cobra.Command{
 	Example: `
   force apiversion
   force apiversion 40.0
+  force apiversion list
 `,
 	Args:                  cobra.MaximumNArgs(1),
 	DisableFlagsInUseLine: true,
@@ -27,20 +35,42 @@ var apiVersionCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	RootCmd.AddCommand(apiVersionCmd)
+var apiVersionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List API versions supported by org",
+	Example: `
+  force apiversion list
+`,
+	Args:                  cobra.MaximumNArgs(0),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		json, _ := cmd.Flags().GetBool("json")
+		listApiVersions(json)
+	},
 }
 
 func setApiVersion(apiVersionNumber string) {
-	matched, err := regexp.MatchString("^\\d{2}\\.0$", apiVersionNumber)
+	err := force.UpdateApiVersion(apiVersionNumber)
 	if err != nil {
 		ErrorAndExit("%v", err)
 	}
-	if !matched {
-		ErrorAndExit("apiversion must be in the form of nn.0.")
-	}
-	err = force.UpdateApiVersion(apiVersionNumber)
+}
+
+func listApiVersions(jsonOutput bool) {
+	data, err := force.GetAbsolute("/services/data")
 	if err != nil {
-		ErrorAndExit("%v", err)
+		ErrorAndExit(err.Error())
+	}
+	if jsonOutput {
+		fmt.Println(data)
+		return
+	}
+	var versions []map[string]string
+	err = json.Unmarshal([]byte(data), &versions)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+	for _, v := range versions {
+		fmt.Printf("%s (%s)\n", v["version"], v["label"])
 	}
 }

--- a/command/root.go
+++ b/command/root.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	account string
+	account     string
+	_apiVersion string
 
 	force *Force
 )
@@ -27,6 +28,7 @@ func init() {
 	}
 	RootCmd.SetArgs(args)
 	RootCmd.PersistentFlags().StringVarP(&account, "account", "a", "", "account `username` to use")
+	RootCmd.PersistentFlags().StringVarP(&_apiVersion, "apiversion", "V", "", "API version to use")
 }
 
 var RootCmd = &cobra.Command{
@@ -55,6 +57,12 @@ func initializeSession() {
 	}
 	if err != nil {
 		ErrorAndExit(err.Error())
+	}
+	if _apiVersion != "" {
+		err := SetApiVersion(_apiVersion)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
 	}
 }
 

--- a/lib/apiversion.go
+++ b/lib/apiversion.go
@@ -3,10 +3,11 @@ package lib
 import (
 	"fmt"
 	"os"
+	"regexp"
 )
 
 var (
-	DefaultApiVersionNumber = "45.0"
+	DefaultApiVersionNumber = "55.0"
 	apiVersionNumber        = DefaultApiVersionNumber
 	apiVersion              = fmt.Sprintf("v%s", apiVersionNumber)
 )
@@ -19,14 +20,22 @@ func ApiVersionNumber() string {
 	return apiVersionNumber
 }
 
-func (f *Force) UpdateApiVersion(version string) (err error) {
-	SetApiVersion(version)
+func (f *Force) UpdateApiVersion(version string) error {
+	err := SetApiVersion(version)
+	if err != nil {
+		return err
+	}
 	f.Credentials.SessionOptions.ApiVersion = version
 	_, err = ForceSaveLogin(*f.Credentials, os.Stdout)
-	return
+	return err
 }
 
-func SetApiVersion(version string) {
+func SetApiVersion(version string) error {
+	matched, err := regexp.MatchString("^\\d{2}\\.0$", version)
+	if err != nil || !matched {
+		return fmt.Errorf("apiversion must be in the form of nn.0.")
+	}
 	apiVersion = "v" + version
 	apiVersionNumber = version
+	return nil
 }


### PR DESCRIPTION
Add global --apiversion to override current API version set for the
session.

Add `apiversion list` command to show the API versions supported by the
org.
