### PR TITLE
Retry CheckDeployStatus Errors in `force import`; Look for Salesforce Edge Errors

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -749,7 +749,8 @@ func (fm *ForceMetadata) CheckDeployStatus(id string) (results ForceCheckDeploym
 	}
 
 	if err = xml.Unmarshal(body, &deployResult); err != nil {
-		ErrorAndExit(err.Error())
+		err = errors.New("Error decoding SOAP body: " + err.Error())
+		return results, err
 	}
 
 	results = deployResult.Results

--- a/lib/soap.go
+++ b/lib/soap.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"strings"
 )
 
@@ -107,6 +108,10 @@ func (s *Soap) Execute(action, query string) (response []byte, err error) {
 		return
 	}
 	defer res.Body.Close()
+	if res.Header.Get(http.CanonicalHeaderKey("x-sfdc-edge-err")) == "true" {
+		err = errors.New("Unexpected error from Salesforce Edge")
+		return
+	}
 	if res.StatusCode == 401 {
 		err = errors.New("authorization expired, please run `force login`")
 		return


### PR DESCRIPTION
Update `force import` to retry once when CheckDeployStatus returns an
error.  Salesforce Edge sometimes returns intermittent errors.
