### PR TITLE
Print Lines Without Coverage When Coverage Warning

### DIFF
--- a/lib/deploy.go
+++ b/lib/deploy.go
@@ -134,6 +134,16 @@ func processDeployResults(result ForceCheckDeploymentStatusResult, byName bool, 
 		for _, warning := range codeCoverageWarnings {
 			fmt.Printf("\n %s: %s\n", warning.Name, warning.Message)
 		}
+		for _, c := range result.Details.RunTestResult.CodeCoverage {
+			component := c.Name
+			if c.Namespace != "" {
+				component = c.Namespace + "." + c.Name
+			}
+
+			for _, line := range c.LocationsNotCovered {
+				fmt.Printf("%s %s: Line %d not covered\n", c.Type, component, line.Line)
+			}
+		}
 	}
 
 	// Handle notifications

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -138,6 +138,23 @@ type CodeCoverageWarning struct {
 	Message string `xml:"message"`
 }
 
+type CodeCoverage struct {
+	Id                     string               `xml:"id"`
+	LocationsNotCovered    []LocationNotCovered `xml:"locationsNotCovered"`
+	Name                   string               `xml:"name"`
+	Namespace              string               `xml:"namespace"`
+	Type                   string               `xml:"type"`
+	NumLocations           int                  `xml:"numLocations"`
+	NumLocationsNotCovered int                  `xml:"numLocationsNotCovered"`
+}
+
+type LocationNotCovered struct {
+	Column        int     `xml:"column"`
+	Line          int     `xml:"line"`
+	NumExecutions int     `xml:"numExecutions"`
+	Time          float32 `xml:"time"`
+}
+
 type RunTestResult struct {
 	NumberOfFailures     int                   `xml:"numFailures"`
 	NumberOfTestsRun     int                   `xml:"numTestsRun"`
@@ -145,6 +162,7 @@ type RunTestResult struct {
 	TestFailures         []TestFailure         `xml:"failures"`
 	TestSuccesses        []TestSuccess         `xml:"successes"`
 	CodeCoverageWarnings []CodeCoverageWarning `xml:"codeCoverageWarnings"`
+	CodeCoverage         []CodeCoverage        `xml:"codeCoverage"`
 }
 
 type ComponentDetails struct {


### PR DESCRIPTION
When there's a code coverage warning during deployment, print the lines
with no code coverage.
