### PR TITLE
Follow Redirects Refreshing Session Token

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -29,7 +29,8 @@ func (f *Force) refreshOauth() (err error) {
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	Log.Info("Refreshing Session Token")
-	res, err := doRequest(req)
+	// Follow Redirects and re-POST upon a 302 response.
+	res, err := doRequest(req, redirectPostOn302)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
When we get a 302 response while refreshing the session token at
/services/oauth2/token, follow the redirect and re-POST to the new URL.

This can happen if the endpoint URL used to authenticate is valid, but
a non-canonical login URL, e.g.
https://myorg--mysandbox.sandbox.lightning.force.com/
