### PR TITLE
Retry on http errors

### DIFF
--- a/lib/bulk.go
+++ b/lib/bulk.go
@@ -4,10 +4,11 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/ForceCLI/force/lib/internal"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/ForceCLI/force/lib/internal"
 )
 
 type BatchResult struct {
@@ -167,7 +168,7 @@ func (f *Force) BulkQuery(soql string, jobId string, contentType string, request
 	httpCt := httpContentTypeForJobContentType[jct]
 	unmarshal := httpResponseUnmarshalerForJobContentType[jct]
 
-	body, err := f.httpPostPatch(url, soql, httpCt, HttpMethodPost, requestOptions...)
+	body, err := f.httpPostPatchWithRetry(url, soql, httpCt, HttpMethodPost, requestOptions...)
 	if err != nil {
 		return BatchInfo{}, err
 	}
@@ -184,7 +185,7 @@ func (f *Force) AddBatchToJob(content string, job JobInfo) (BatchInfo, error) {
 		return BatchInfo{}, err
 	}
 	url := fmt.Sprintf("%s/services/async/%s/job/%s/batch", f.Credentials.InstanceUrl, apiVersionNumber, job.Id)
-	body, err := f.httpPostPatch(url, content, httpContentTypeForJobContentType[jct], HttpMethodPost)
+	body, err := f.httpPostPatchWithRetry(url, content, httpContentTypeForJobContentType[jct], HttpMethodPost)
 	if err != nil {
 		return BatchInfo{}, err
 	}

--- a/lib/httpaux.go
+++ b/lib/httpaux.go
@@ -164,7 +164,7 @@ func (r *HttpRetrier) BackoffDelay(bd time.Duration) *HttpRetrier {
 	return r
 }
 
-func NewHttpRetrier(maxAttempts int, backoffDelay time.Duration, retryOnErrors []func(res *http.Response, err error) bool) *HttpRetrier {
+func NewHttpRetrier(maxAttempts int, backoffDelay time.Duration, retryOnErrors ...func(res *http.Response, err error) bool) *HttpRetrier {
 	return &HttpRetrier{
 		maxAttempts:   maxAttempts,
 		retryOnErrors: retryOnErrors,

--- a/lib/httpaux.go
+++ b/lib/httpaux.go
@@ -179,7 +179,6 @@ func (r *HttpRetrier) shouldRetry(res *http.Response, err error) bool {
 	if r.attempt >= r.maxAttempts {
 		return false
 	}
-
 	r.attempt += 1
 
 	for _, f := range r.retryOnErrors {

--- a/lib/httpaux_test.go
+++ b/lib/httpaux_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
@@ -22,30 +21,54 @@ var _ = Describe("HttpRetrier", func() {
 				return err == nil
 			},
 			func(res *http.Response, err error) bool {
-				calls++
+				calls += 1
 				return err == err
 			},
 		)
 		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
-		force := &Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}
+		force := (&Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}).WithRetrier(retrier)
 
-		force.WithRetrier(retrier).ExecuteRequest(request)
-
-		retrier.shouldRetry(nil, errors.New("i am fundamentally wrong"))
+		force.ExecuteRequest(request)
 
 		Expect(calls).To(Equal(retrier.maxAttempts))
 	})
 
-	It("retries only on specified errors", func() {
+	It("retries only on errors", func() {
 		calls := 0
-		retrier := newTestHttpRetrier()
-		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
-		force := &Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}
+		retrier := newTestHttpRetrier(func(res *http.Response, err error) bool {
+			calls += 1
+			return err == nil
+		})
+		request := NewRequest("GET").RootUrl("/")
+		force := (&Force{Credentials: &ForceSession{InstanceUrl: "https://google.com"}}).WithRetrier(retrier)
 
-		force.WithRetrier(retrier).ExecuteRequest(request)
-
-		retrier.shouldRetry(nil, errors.New("i am fundamentally wrong"))
+		force.ExecuteRequest(request)
 
 		Expect(calls).To(Equal(0))
+	})
+
+	It("retries only on specified errors", func() {
+		calls := 0
+		retrier := newTestHttpRetrier(func(res *http.Response, err error) bool {
+			calls += 1
+			return err == nil
+		})
+		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
+		force := (&Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}).WithRetrier(retrier)
+
+		force.ExecuteRequest(request)
+
+		Expect(calls).To(Equal(1))
+	})
+
+	It("retrier is not mutated", func() {
+		retrier := newTestHttpRetrier()
+		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
+		force := (&Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}).WithRetrier(retrier)
+
+		force.ExecuteRequest(request)
+
+		Expect(force.retrier.attempt).To(Equal(0))
+		Expect(retrier.attempt).To(Equal(0))
 	})
 })

--- a/lib/httpaux_test.go
+++ b/lib/httpaux_test.go
@@ -9,15 +9,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func newTestHttpRetrier(retryOnErrors []func(res *http.Response, err error) bool) *HttpRetrier {
-	return NewHttpRetrier(2, time.Duration(0), retryOnErrors)
+func newTestHttpRetrier(retryOnErrors ...func(res *http.Response, err error) bool) *HttpRetrier {
+	return NewHttpRetrier(2, time.Duration(0), retryOnErrors...)
 
 }
 
 var _ = Describe("HttpRetrier", func() {
 	It("retries at most max attempts", func() {
 		calls := 0
-		retrier := newTestHttpRetrier([]func(res *http.Response, err error) bool{
+		retrier := newTestHttpRetrier(
 			func(res *http.Response, err error) bool {
 				return err == nil
 			},
@@ -25,7 +25,7 @@ var _ = Describe("HttpRetrier", func() {
 				calls++
 				return err == err
 			},
-		})
+		)
 		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
 		force := &Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}
 
@@ -38,7 +38,7 @@ var _ = Describe("HttpRetrier", func() {
 
 	It("retries only on specified errors", func() {
 		calls := 0
-		retrier := newTestHttpRetrier([]func(res *http.Response, err error) bool{})
+		retrier := newTestHttpRetrier()
 		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
 		force := &Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}
 

--- a/lib/httpaux_test.go
+++ b/lib/httpaux_test.go
@@ -1,0 +1,51 @@
+package lib
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func newTestHttpRetrier(retryOnErrors []func(res *http.Response, err error) bool) *HttpRetrier {
+	return NewHttpRetrier(2, time.Duration(0), retryOnErrors)
+
+}
+
+var _ = Describe("HttpRetrier", func() {
+	It("retries at most max attempts", func() {
+		calls := 0
+		retrier := newTestHttpRetrier([]func(res *http.Response, err error) bool{
+			func(res *http.Response, err error) bool {
+				return err == nil
+			},
+			func(res *http.Response, err error) bool {
+				calls++
+				return err == err
+			},
+		})
+		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
+		force := &Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}
+
+		force.WithRetrier(retrier).ExecuteRequest(request)
+
+		retrier.shouldRetry(nil, errors.New("i am fundamentally wrong"))
+
+		Expect(calls).To(Equal(retrier.maxAttempts))
+	})
+
+	It("retries only on specified errors", func() {
+		calls := 0
+		retrier := newTestHttpRetrier([]func(res *http.Response, err error) bool{})
+		request := NewRequest("i am fundamentally wrong").RootUrl("wrong.com")
+		force := &Force{Credentials: &ForceSession{InstanceUrl: "instance.com"}}
+
+		force.WithRetrier(retrier).ExecuteRequest(request)
+
+		retrier.shouldRetry(nil, errors.New("i am fundamentally wrong"))
+
+		Expect(calls).To(Equal(0))
+	})
+})

--- a/lib/request.go
+++ b/lib/request.go
@@ -141,10 +141,6 @@ func (f *Force) ExecuteRequest(r *Request) (*Response, error) {
 
 	retrier := f.GetRetrier()
 
-	if retrier == nil {
-		retrier = &HttpRetrier{}
-	}
-
 	reqResp := &Response{}
 	inp := &httpRequestInput{
 		Method:   r.method,

--- a/lib/request.go
+++ b/lib/request.go
@@ -131,9 +131,6 @@ func (r *Request) toHttpCallback(forceResponse *Response) HttpCallback {
 // ExecuteRequest executes an HTTP request based on Request,
 // processes the HTTP response in the configured way,
 // and returns the Response.
-//
-// ExecuteRequest will retry once on a SessionExpired error
-// (future versions may allow configurable retry behavior).
 func (f *Force) ExecuteRequest(r *Request) (*Response, error) {
 	var absUrl string
 	if r.absoluteUrl != "" {
@@ -141,13 +138,20 @@ func (f *Force) ExecuteRequest(r *Request) (*Response, error) {
 	} else {
 		absUrl = f.qualifyUrl(r.rootedUrl)
 	}
+
+	retrier := f.GetRetrier()
+
+	if retrier == nil {
+		retrier = &HttpRetrier{}
+	}
+
 	reqResp := &Response{}
 	inp := &httpRequestInput{
 		Method:   r.method,
 		Url:      absUrl,
 		Headers:  r.Headers,
 		Callback: r.toHttpCallback(reqResp),
-		Retrier:  (&httpRetrier{}).Reauth(),
+		retrier:  retrier,
 		Body:     r.body,
 	}
 	if !r.unauthed {


### PR DESCRIPTION
Expand `HttpRetrier` to support retrying with delay for arbitraty errors.