### PR TITLE
Add `search` Command

### DIFF
--- a/command/search.go
+++ b/command/search.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/ForceCLI/force/error"
+	. "github.com/ForceCLI/force/lib"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(searchCmd)
+}
+
+var searchCmd = &cobra.Command{
+	Use:   "search [flags] <sosl statement>",
+	Short: "Execute a SOSL statement",
+	Example: `
+  force search "FIND {Jane Doe} IN ALL FIELDS RETURNING Account (Id, Name)"
+`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		format, _ := cmd.Flags().GetString("format")
+		query := strings.Join(args, " ")
+		runSearch(query, format)
+	},
+}
+
+func runSearch(query string, format string) {
+	records, err := force.Search(query)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+	fmt.Print(RenderForceRecords(records))
+}

--- a/lib/force.go
+++ b/lib/force.go
@@ -181,6 +181,10 @@ type ForceQueryResult struct {
 	NextRecordsUrl string
 }
 
+type ForceSearchResult struct {
+	SearchRecords []ForceRecord `json:"searchRecords"`
+}
+
 type ForceSobjectsResult struct {
 	Encoding     string
 	MaxBatchSize int
@@ -733,6 +737,20 @@ func (f *Force) legacyQueryOptions(qs string, options ...func(*QueryOptions)) []
 		qopts = append(qopts, query.Tooling)
 	}
 	return qopts
+}
+
+func (f *Force) Search(qs string) ([]ForceRecord, error) {
+	url := "/search/?q=" + url.QueryEscape(qs)
+	body, err := f.makeHttpRequestSync(NewRequest("GET").RestUrl(url))
+	if err != nil {
+		return nil, err
+	}
+	r := ForceSearchResult{}
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return nil, err
+	}
+	return r.SearchRecords, nil
 }
 
 func (f *Force) Get(url string) (object ForceRecord, err error) {


### PR DESCRIPTION
Add `search` command to perform a SOSL search.
