### PR TITLE
Allow Deploying destructiveChanges.xml Outside of Root Directory

### DIFF
--- a/lib/packagebuilder.go
+++ b/lib/packagebuilder.go
@@ -407,16 +407,19 @@ func (pb *PackageBuilder) addFileAndMetaXml(fpath string) error {
 func (pb *PackageBuilder) addFileOnly(fpath string) (err error) {
 	fdata, err := ioutil.ReadFile(fpath)
 	if err != nil {
-		return
+		return err
 	}
 
 	frel, err := filepath.Rel(pb.Root, fpath)
 	if err != nil {
 		return err
 	}
+	if !filepath.IsLocal(frel) {
+		frel = filepath.Base(frel)
+	}
 	pb.Files[frel] = fdata
 
-	return
+	return err
 }
 
 func (pb *PackageBuilder) contains(members []string, name string) bool {

--- a/lib/packagebuilder_test.go
+++ b/lib/packagebuilder_test.go
@@ -162,13 +162,13 @@ var _ = Describe("Packagebuilder", func() {
 		})
 
 		Context("when adding a destructiveChanges file", func() {
-			var destructiveChangesPath string
+			var tempDir string
 
 			BeforeEach(func() {
 				pb = NewPushBuilder()
-				tempDir, _ := ioutil.TempDir("", "packagebuilder-test")
-				pb.Root = tempDir
-				destructiveChangesPath = tempDir + "/src/destructiveChanges.xml"
+				tempDir, _ = ioutil.TempDir("", "packagebuilder-test")
+				pb.Root = tempDir + "/src"
+				destructiveChangesPath := tempDir + "/src/destructiveChanges.xml"
 				destructiveChangesXml := `<?xml version="1.0" encoding="UTF-8"?>
 					<Package xmlns="http://soap.sforce.com/2006/04/metadata">
 					<version>34.0</version>
@@ -176,16 +176,22 @@ var _ = Describe("Packagebuilder", func() {
 				`
 				mustMkdir(tempDir + "/src")
 				mustWrite(destructiveChangesPath, destructiveChangesXml)
+				mustWrite(tempDir+"/destructiveChanges.xml", destructiveChangesXml)
 			})
 
 			It("should add the file to package", func() {
-				err := pb.AddFile(destructiveChangesPath)
+				err := pb.AddFile(tempDir + "/src/destructiveChanges.xml")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(pb.Files).To(HaveKey("src/destructiveChanges.xml"))
+				Expect(pb.Files).To(HaveKey("destructiveChanges.xml"))
 			})
 			It("should not add the file to the package.xml", func() {
-				pb.AddFile(destructiveChangesPath)
+				pb.AddFile(tempDir + "/src/destructiveChanges.xml")
 				Expect(pb.Metadata).To(BeEmpty())
+			})
+			It("should allow adding the file outside the root directory", func() {
+				err := pb.AddFile(tempDir + "/destructiveChanges.xml")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pb.Files).To(HaveKey("destructiveChanges.xml"))
 			})
 		})
 	})


### PR DESCRIPTION
If metadata is in ./src/, allow deploying destructiveChanges.xml stored
in ./destructiveChanges.xml.
