### PR TITLE
Fix Pushing Foldered Metadata On Windows

### DIFF
--- a/lib/packagebuilder.go
+++ b/lib/packagebuilder.go
@@ -441,8 +441,9 @@ func (pb *PackageBuilder) AddMetaToPackage(metaName string, name string) {
 		mt.Name = metaName
 	}
 
-	if !pb.contains(mt.Members, name) {
-		mt.Members = append(mt.Members, name)
+	canonicalName := filepath.ToSlash(name)
+	if !pb.contains(mt.Members, canonicalName) {
+		mt.Members = append(mt.Members, canonicalName)
 		pb.Metadata[metaName] = mt
 	}
 }


### PR DESCRIPTION
Fix pushing foldered metadata such as reports on Windows.
Generate package.xml with slashes rather than the OS-specific path
separator, backslash on Windows.
