### PR TITLE
Fix force import Exit Code

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -93,7 +93,7 @@ func deploy(force *Force, files ForceMetadataFiles, deployOptions *ForceDeployOp
 			return fmt.Errorf("Failed to generate output: %w", err)
 		}
 		fmt.Println(output)
-		if result.HasComponentFailures() || (result.HasTestFailures() && exitCodeOnTestFailure) || !result.Success {
+		if result.HasComponentFailures() || (result.HasTestFailures() && errorOnTestFailure) || !result.Success {
 			return fmt.Errorf("Deploy unsuccessful")
 		}
 		return nil
@@ -123,7 +123,7 @@ func deploy(force *Force, files ForceMetadataFiles, deployOptions *ForceDeployOp
 
 		if result.HasComponentFailures() {
 			err = errors.New("Some components failed deployment")
-		} else if result.HasTestFailures() && exitCodeOnTestFailure {
+		} else if result.HasTestFailures() && errorOnTestFailure {
 			err = errors.New("Some tests failed")
 		} else if !result.Success {
 			err = errors.New(fmt.Sprintf("Status: %s, Status Code: %s, Error Message: %s", result.Status, result.ErrorStatusCode, result.ErrorMessage))

--- a/command/import.go
+++ b/command/import.go
@@ -34,7 +34,7 @@ func init() {
 
 	importCmd.Flags().StringP("directory", "d", "src", "relative path to package.xml")
 
-	importCmd.Flags().BoolVarP(&exitCodeOnTestFailure, "erroronfailure", "E", true, "exit with an error code if any tests fail")
+	importCmd.Flags().BoolVarP(&errorOnTestFailure, "erroronfailure", "E", true, "exit with an error code if any tests fail")
 
 	RootCmd.AddCommand(importCmd)
 }
@@ -59,7 +59,7 @@ var importCmd = &cobra.Command{
 }
 
 var (
-	exitCodeOnTestFailure bool
+	errorOnTestFailure bool
 )
 
 func sourceDir(cmd *cobra.Command) string {
@@ -119,7 +119,7 @@ func runImport(root string, options ForceDeployOptions, displayOptions *deployOu
 	if err == nil && displayOptions.reportFormat == "text" && !displayOptions.quiet {
 		fmt.Printf("Imported from %s\n", root)
 	}
-	if err != nil && exitCodeOnTestFailure {
+	if err != nil {
 		ErrorAndExit(err.Error())
 	}
 }


### PR DESCRIPTION
Fix exit code of `force import` when `--erroronfailure=false` and the
deploy fails (as opposed to an apex test failing).  Exit with exit code
1.
