### PR TITLE
Improve Query Output With Empty Relationship Values

### DIFF
--- a/lib/display.go
+++ b/lib/display.go
@@ -22,6 +22,12 @@ SystemModstamp 		%s
 NumberRecordsProcessed  %d
 `
 
+type NullValue string
+
+const nullFieldValue NullValue = ""
+
+func (e NullValue) String() string { return "(null)" }
+
 type ByXmlName []DescribeMetadataObject
 
 func (a ByXmlName) Len() int           { return len(a) }
@@ -323,7 +329,7 @@ func recordRow(record ForceRecord, columns []string, lengths map[string]int, pre
 			values[i] = strings.TrimSuffix(renderForceRecords(value, fmt.Sprintf("%s.%s", prefix, column), lengths), "\n")
 		default:
 			if value == nil {
-				values[i] = fmt.Sprintf(fmt.Sprintf(" %%-%ds ", lengths[column]-2), "(null)")
+				values[i] = fmt.Sprintf(fmt.Sprintf(" %%-%ds ", lengths[column]-2), "")
 			} else {
 				values[i] = fmt.Sprintf(fmt.Sprintf(" %%-%dv ", lengths[column]-2), value)
 			}
@@ -408,6 +414,10 @@ func flattenForceRecord(record ForceRecord) (flattened ForceRecord) {
 	flattened = make(ForceRecord)
 	for key, value := range record {
 		if key == "attributes" {
+			continue
+		}
+		if value == nil {
+			flattened[key] = nullFieldValue
 			continue
 		}
 		switch value := value.(type) {


### PR DESCRIPTION
Update the default console table output to only output "(null)" when a
field is null.  Output an empty string when there is output for the row.

This changes the output when querying relationships.

For example, assume the field My_Relationship__r.My_Field__c is queried and
there are two rows in the output.

If My_Relationship__c is null, "(null)" will be displayed for
My_Relationship__r and nothing will be displayed for
My_Relationship__r.My_Field__c.

If My_Relationship__c is not null, nothing will be displayed for
My_Relationship__r (which is only included in the output if there is
another row where My_Relationship__c is null).
My_Relationship__r.My_Field__c will still display "(null)" if
My_Field__c is null.
