### PR TITLE
Use Integer Replay Ids By Default

### DIFF
--- a/lib/pubsub/grpcclient.go
+++ b/lib/pubsub/grpcclient.go
@@ -3,7 +3,7 @@ package pubsub
 import (
 	"context"
 	"crypto/x509"
-	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -189,7 +189,7 @@ func (c *PubSubClient) Subscribe(channel string, replayPreset proto.ReplayPreset
 				return curReplayId, err
 			}
 			fmt.Println(string(j))
-			Log.Info(fmt.Sprintf("ReplayId (%s): %s", channel, base64.StdEncoding.EncodeToString(curReplayId)))
+			Log.Info(fmt.Sprintf("ReplayId (%s): %d", channel, int64(binary.BigEndian.Uint64(curReplayId))))
 
 			// decrement our counter to keep track of how many events have been requested but not yet processed. If we're below our configured
 			// batch size then proactively request more events to stay ahead of the processor


### PR DESCRIPTION
Display platform event replay ids as integers rather than base64-encoded
byte arrays.  Allow either the integer or base64 value to be used when
passing a replay id to `pubsub subscribe`.
