### PR TITLE
Add Interactive Mode for `force push` and `force import`

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -30,6 +30,7 @@ func init() {
 	importCmd.Flags().BoolP("ignorecoverage", "w", false, "suppress code coverage warnings")
 	importCmd.Flags().BoolP("suppressunexpected", "U", true, `suppress "An unexpected error occurred" messages`)
 	importCmd.Flags().BoolP("quiet", "q", false, "only output failures")
+	importCmd.Flags().BoolP("interactive", "I", false, "interactive mode")
 	importCmd.Flags().CountP("verbose", "v", "give more verbose output")
 	importCmd.Flags().StringP("reporttype", "f", "text", "report type format (text or junit)")
 

--- a/command/push.go
+++ b/command/push.go
@@ -29,6 +29,7 @@ func init() {
 	pushCmd.Flags().BoolP("suppressunexpected", "U", false, `suppress "An unexpected error occurred" messages`)
 	pushCmd.Flags().BoolP("quiet", "q", false, "only output failures")
 	pushCmd.Flags().CountP("verbose", "v", "give more verbose output")
+	pushCmd.Flags().BoolP("interactive", "I", false, "interactive mode")
 	pushCmd.Flags().String("reporttype", "text", "report type format (text or junit)")
 
 	// Ways to push


### PR DESCRIPTION
Initial support for an interactive mode for `force push` and `force
push`, in which the screen updates with the status, like `force deploys
watch`.
