### PR TITLE
Add `--username` Flag for `login scratch`

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -23,6 +23,8 @@ func init() {
 logged in system. non-production server to login to (values are 'pre',
 'test', or full instance url`)
 
+	scratchCmd.Flags().String("username", "", "username for scratch org user")
+
 	loginCmd.AddCommand(scratchCmd)
 	RootCmd.AddCommand(loginCmd)
 }
@@ -31,7 +33,8 @@ var scratchCmd = &cobra.Command{
 	Use:   "scratch",
 	Short: "Create scratch org and log in",
 	Run: func(cmd *cobra.Command, args []string) {
-		scratchLogin()
+		scratchUser, _ := cmd.Flags().GetString("username")
+		scratchLogin(scratchUser)
 	},
 }
 
@@ -74,8 +77,8 @@ to get a new session token automatically when needed.`,
 	},
 }
 
-func scratchLogin() {
-	_, err := ForceScratchLoginAndSave(os.Stderr)
+func scratchLogin(scratchUser string) {
+	_, err := ForceScratchCreateLoginAndSave(scratchUser, os.Stderr)
 	if err != nil {
 		ErrorAndExit(err.Error())
 	}

--- a/lib/auth.go
+++ b/lib/auth.go
@@ -109,13 +109,17 @@ func ForceLoginAtEndpointAndSaveSoap(endpoint string, user_name string, password
 
 // Create a new scratch org, login, and make it active
 func ForceScratchLoginAndSave(output *os.File) (username string, err error) {
+	return ForceScratchCreateLoginAndSave("", output)
+}
+
+func ForceScratchCreateLoginAndSave(scratchUser string, output *os.File) (username string, err error) {
 	force, err := ActiveForce()
 	if err != nil {
 		err = errors.New("You must be logged into a Dev Hub org to authenticate as a scratch org user.")
 		return
 	}
 	fmt.Fprintln(os.Stderr, "Creating new Scratch Org...")
-	scratchOrgId, err := force.CreateScratchOrg()
+	scratchOrgId, err := force.CreateScratchOrgWithUser(scratchUser)
 	if err != nil {
 		return
 	}

--- a/lib/scratch.go
+++ b/lib/scratch.go
@@ -53,7 +53,7 @@ func (f *Force) ForceLoginNewScratch(scratchOrgId string) (session ForceSession,
 		RefreshMethod: RefreshOauth,
 	}
 	session.ForceEndpoint = EndpointTest
-	session.ClientId = "SalesforceDevelopmentExperience"
+	session.ClientId = "PlatformCLI"
 	return
 }
 
@@ -63,8 +63,7 @@ func (s *ScratchOrg) getSession() (session ForceSession, err error) {
 	attrs := url.Values{}
 	attrs.Set("grant_type", "authorization_code")
 	attrs.Set("code", s.AuthCode)
-	attrs.Set("client_id", "SalesforceDevelopmentExperience")
-	attrs.Set("client_secret", "1384510088588713504")
+	attrs.Set("client_id", "PlatformCLI")
 	attrs.Set("redirect_uri", "http://localhost:1717/OauthRedirect")
 
 	postVars := attrs.Encode()
@@ -105,13 +104,20 @@ func (s *ScratchOrg) getSession() (session ForceSession, err error) {
 
 // Create a new Scratch Org from a Dev Hub Org
 func (f *Force) CreateScratchOrg() (id string, err error) {
+	return f.CreateScratchOrgWithUser("")
+}
+
+func (f *Force) CreateScratchOrgWithUser(username string) (id string, err error) {
 	params := make(map[string]string)
 	params["ConnectedAppCallbackUrl"] = "http://localhost:1717/OauthRedirect"
-	params["ConnectedAppConsumerKey"] = "SalesforceDevelopmentExperience"
+	params["ConnectedAppConsumerKey"] = "PlatformCLI"
 	params["Country"] = "US"
 	params["Edition"] = "Developer"
 	params["Features"] = "AuthorApex;API;AddCustomApps:30;AddCustomTabs:30;ForceComPlatform;Sites;CustomerSelfService"
 	params["OrgName"] = "Force CLI Scratch"
+	if username != "" {
+		params["Username"] = username
+	}
 	id, err, messages := f.CreateRecord("ScratchOrgInfo", params)
 	if err != nil {
 		if len(messages) == 1 && messages[0].ErrorCode == "NOT_FOUND" {


### PR DESCRIPTION
Add `--username` flag for `login scratch` to specify the username of the default user in a new scratch org.

Update the default connected app to use for scratch orgs to be consistent with `sf`.