### PR TITLE
Update Example for `export`

### DIFF
--- a/command/export.go
+++ b/command/export.go
@@ -26,7 +26,7 @@ var exportCmd = &cobra.Command{
 	Short: "Export metadata to a local directory",
 	Example: `
   force export
-  force export org/schema
+  force export [directory]
   force export -x ApexClass -x CustomObject
 `,
 	Args: cobra.MaximumNArgs(1),


### PR DESCRIPTION
Update example usage for `export` to clarify that the optional argument
is a directory name to which the export should be written.
