### PR TITLE
Multiple accounts for deployment

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
-	. "github.com/ForceCLI/force/error"
 	. "github.com/ForceCLI/force/lib"
 	"github.com/spf13/cobra"
 )
@@ -38,53 +38,41 @@ func defaultDeployOutputOptions() *deployOutputOptions {
 
 var testFailureError = errors.New("Apex tests failed")
 
-func monitorDeploy(deployId string) (ForceCheckDeploymentStatusResult, error) {
-	var result ForceCheckDeploymentStatusResult
-	var err error
-	retrying := false
-	for {
-		result, err = force.Metadata.CheckDeployStatus(deployId)
-		if err != nil {
-			if retrying {
-				return result, fmt.Errorf("Error getting deploy status: %w", err)
-			} else {
-				retrying = true
-				Log.Info(fmt.Sprintf("Received error checking deploy status: %s.  Will retry once before aborting.", err.Error()))
-			}
-		} else {
-			retrying = false
-		}
-		if result.Done {
-			break
-		}
-		if !retrying {
-			Log.Info(result)
-		}
-		time.Sleep(5000 * time.Millisecond)
-	}
-	return result, err
+type deployStatus struct {
+	mu      sync.Mutex
+	aborted bool
+}
+
+func (c *deployStatus) abort() {
+	c.mu.Lock()
+	c.aborted = true
+	c.mu.Unlock()
+}
+
+func (c *deployStatus) isAborted() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.aborted
 }
 
 func deploy(force *Force, files ForceMetadataFiles, deployOptions *ForceDeployOptions, outputOptions *deployOutputOptions) error {
-	if outputOptions.quiet {
-		previousLogger := Log
-		var l quietLogger
-		Log = l
-		defer func() {
-			Log = previousLogger
-		}()
-	}
+	status := deployStatus{aborted: false}
+
+	return deployWith(force, &status, files, deployOptions, outputOptions)
+}
+
+func deployWith(force *Force, status *deployStatus, files ForceMetadataFiles, deployOptions *ForceDeployOptions, outputOptions *deployOutputOptions) error {
 	startTime := time.Now()
 	deployId, err := force.Metadata.StartDeploy(files, *deployOptions)
 	if err != nil {
-		ErrorAndExit(err.Error())
+		return err
 	}
 	stopDeployUponSignal(force, deployId)
 	if outputOptions.interactive {
 		watchDeploy(deployId)
 		return nil
 	}
-	result, err := monitorDeploy(deployId)
+	result, err := monitorDeploy(force, deployId, status)
 	if err != nil {
 		return err
 	}
@@ -154,6 +142,39 @@ func deploy(force *Force, files ForceMetadataFiles, deployOptions *ForceDeployOp
 		}
 	}
 	return nil
+}
+
+func monitorDeploy(force *Force, deployId string, status *deployStatus) (ForceCheckDeploymentStatusResult, error) {
+	var result ForceCheckDeploymentStatusResult
+	var err error
+	retrying := false
+	for {
+		if status.isAborted() {
+			fmt.Fprintf(os.Stderr, "Cancelling deploy %s\n", deployId)
+			force.Metadata.CancelDeploy(deployId)
+			return result, nil
+		}
+		result, err = force.Metadata.CheckDeployStatus(deployId)
+		if err != nil {
+			if retrying {
+				return result, fmt.Errorf("Error getting deploy status: %w", err)
+			} else {
+				retrying = true
+				Log.Info(fmt.Sprintf("Received error checking deploy status: %s.  Will retry once before aborting.", err.Error()))
+			}
+		} else {
+			retrying = false
+		}
+		result.UserName = force.GetCredentials().UserInfo.UserName
+		if result.Done {
+			break
+		}
+		if !retrying {
+			Log.Info(result)
+		}
+		time.Sleep(5000 * time.Millisecond)
+	}
+	return result, err
 }
 
 func stopDeployUponSignal(force *Force, deployId string) {

--- a/command/logout.go
+++ b/command/logout.go
@@ -37,7 +37,7 @@ func runLogout() {
 		SetActiveLoginDefault()
 	}
 	if runtime.GOOS == "windows" {
-		cmd := exec.Command("title", account)
+		cmd := exec.Command("title", username)
 		cmd.Run()
 	} else {
 		title := fmt.Sprintf("\033];%s\007", "")

--- a/command/root.go
+++ b/command/root.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	account     string
+	accounts    []string
 	configName  string
 	_apiVersion string
 
-	force *Force
+	manager forceManager
+	force   *Force
 )
 
 func init() {
@@ -30,7 +31,7 @@ func init() {
 		}
 	}
 	RootCmd.SetArgs(args)
-	RootCmd.PersistentFlags().StringVarP(&account, "account", "a", "", "account `username` to use")
+	RootCmd.PersistentFlags().StringArrayVarP(&accounts, "account", "a", []string{}, "account `username` to use")
 	RootCmd.PersistentFlags().StringVar(&configName, "config", "", "config directory to use (default: .force)")
 	RootCmd.PersistentFlags().StringVarP(&_apiVersion, "apiversion", "V", "", "API version to use")
 }
@@ -61,21 +62,16 @@ func initializeConfig() {
 }
 
 func initializeSession() {
-	var err error
-	if account != "" {
-		force, err = GetForce(account)
-	} else {
-		force, err = ActiveForce()
-	}
-	if err != nil {
-		ErrorAndExit(err.Error())
-	}
+	manager = newForceManager(accounts)
+
 	if _apiVersion != "" {
 		err := SetApiVersion(_apiVersion)
 		if err != nil {
 			ErrorAndExit(err.Error())
 		}
 	}
+
+	force = manager.getCurrentForce()
 }
 
 func Execute() {
@@ -88,4 +84,60 @@ func Execute() {
 type quietLogger struct{}
 
 func (l quietLogger) Info(args ...interface{}) {
+}
+
+// provides support for commands that can be run concurrently for many accounts
+type forceManager struct {
+	connections    map[string]*Force
+	currentAccount string
+}
+
+func (manager forceManager) getCurrentForce() *Force {
+	return manager.connections[manager.currentAccount]
+}
+
+func (manager forceManager) getAllForce() []*Force {
+	fs := make([]*Force, 0, len(manager.connections))
+
+	for _, v := range manager.connections {
+		fs = append(fs, v)
+	}
+	return fs
+}
+
+func newForceManager(accounts []string) forceManager {
+	var err error
+	fm := forceManager{connections: make(map[string]*Force, 1)}
+
+	if len(accounts) > 1 {
+		for _, a := range accounts {
+			var f *Force
+
+			f, err = GetForce(a)
+			if err != nil {
+				ErrorAndExit(err.Error())
+			}
+
+			fm.connections[a] = f
+		}
+
+		fm.currentAccount = accounts[0]
+	} else {
+		var f *Force
+
+		if len(accounts) == 0 {
+			f, err = ActiveForce()
+		} else {
+			f, err = GetForce(accounts[0])
+		}
+
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+
+		fm.currentAccount = f.GetCredentials().UserInfo.UserName
+		fm.connections[fm.currentAccount] = f
+	}
+
+	return fm
 }

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -172,6 +172,7 @@ type ComponentDetails struct {
 }
 
 type ForceCheckDeploymentStatusResult struct {
+	UserName                 string
 	CheckOnly                bool             `xml:"checkOnly"`
 	CompletedDate            time.Time        `xml:"completedDate"`
 	CreatedDate              time.Time        `xml:"createdDate"`
@@ -743,7 +744,7 @@ func (results ForceCheckDeploymentStatusResult) String() string {
 		complete = fmt.Sprintf(" (%d/%d)", results.NumberTestsCompleted, results.NumberTestsTotal)
 	}
 
-	return fmt.Sprintf("Status: %s%s %s", results.Status, complete, results.StateDetail)
+	return fmt.Sprintf("Status (%s): %s%s %s", results.UserName, results.Status, complete, results.StateDetail)
 }
 
 func (fm *ForceMetadata) CancelDeploy(id string) (ForceCancelDeployResult, error) {


### PR DESCRIPTION
Add support for several --account flags. The accounts passed must already have been logged in. `force import` uses a mutex to synchonize concurrent deployments.