### PR TITLE
Use ScratchOrgInfo.LoginUrl to Exchange Scratch Org User Token for Session Id

### DIFF
--- a/lib/scratch.go
+++ b/lib/scratch.go
@@ -33,7 +33,7 @@ func (f *Force) getScratchOrg(scratchOrgId string) (scratchOrg ScratchOrg, err e
 	}
 	scratchOrg = ScratchOrg{
 		UserName:    org["SignupUsername"].(string),
-		InstanceUrl: fmt.Sprintf("https://%s.salesforce.com", org["SignupInstance"].(string)),
+		InstanceUrl: org["LoginUrl"].(string),
 		AuthCode:    org["AuthCode"].(string),
 	}
 	return


### PR DESCRIPTION
When using `force login scratch`, use ScratchOrgInfo.LoginUrl to
exchange the authorization code for a session id.  Constructing the URL
from ScratchOrgInfo.SignupInstance no longer works.

HT: Jason Lantz
