### PR TITLE
README: Use go install, not go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Can be downloaded from the [Current Release Page](https://github.com/ForceCLI/fo
 
 ##### Compile from Source
 
-    $ go get -u github.com/ForceCLI/force
+    $ go install github.com/ForceCLI/force@latest
 
 ### Usage
 


### PR DESCRIPTION
I get this error using go get:

```
$ go get -u github.com/ForceCLI/force
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

I think using `go install` is the right thing to do now?