### PR TITLE
Add Support for Client Credentials Flow

### DIFF
--- a/lib/jwt.go
+++ b/lib/jwt.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"time"
@@ -19,7 +19,7 @@ func JwtAssertion(endpoint ForceEndpoint, username string, keyfile string, clien
 }
 
 func JwtAssertionForEndpoint(endpoint string, username string, keyfile string, clientId string) (signedToken string, err error) {
-	keyData, err := ioutil.ReadFile(keyfile)
+	keyData, err := os.ReadFile(keyfile)
 	if err != nil {
 		return
 	}
@@ -65,7 +65,7 @@ func JWTLoginAtEndpoint(endpoint string, assertion string) (creds ForceSession, 
 		return
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return
 	}
@@ -95,6 +95,58 @@ func ForceLoginAndSaveJWT(endpoint ForceEndpoint, assertion string, output *os.F
 
 func ForceLoginAtEndpointAndSaveJWT(endpoint string, assertion string, output *os.File) (username string, err error) {
 	creds, err := JWTLoginAtEndpoint(endpoint, assertion)
+	if err != nil {
+		return
+	}
+	username, err = ForceSaveLogin(creds, output)
+	return
+}
+
+func ClientCredentialsLoginAtEndpoint(endpoint string, clientId string, clientSecret string) (creds ForceSession, err error) {
+	attrs := url.Values{}
+	attrs.Set("grant_type", "client_credentials")
+	attrs.Set("client_id", clientId)
+	attrs.Set("client_secret", clientSecret)
+
+	postVars := attrs.Encode()
+	tokenURL := tokenURL(endpoint)
+	if err != nil {
+		return
+	}
+	req, err := httpRequest("POST", tokenURL, bytes.NewReader([]byte(postVars)))
+	if err != nil {
+		return
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	res, err := doRequest(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return
+	}
+
+	if res.StatusCode != 200 {
+		var oauthError *OAuthError
+		err = json.Unmarshal(body, &oauthError)
+		if err != nil {
+			return
+		}
+		err = errors.New(oauthError.ErrorDescription)
+		return
+	}
+
+	err = json.Unmarshal(body, &creds)
+	creds.SessionOptions = &SessionOptions{}
+	creds.EndpointUrl = endpoint
+	creds.ClientId = ClientId
+	return
+}
+
+func ForceLoginAtEndpointAndSaveClientCredentials(endpoint string, clientId string, clientSecret string, output *os.File) (username string, err error) {
+	creds, err := ClientCredentialsLoginAtEndpoint(endpoint, clientId, clientSecret)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Add `--connected-app-client-secret` flag to `force login` to support
Client Credentials flow.
