### PR TITLE
Publish Multiple Pub/Sub Messages From Stdin

### DIFF
--- a/lib/pubsub/publish.go
+++ b/lib/pubsub/publish.go
@@ -49,3 +49,48 @@ func Publish(f *Force, channel string, message map[string]any) error {
 	}
 	return nil
 }
+
+func PublishMessages(f *Force, channel string, messages <-chan map[string]any) error {
+	var err error
+
+	Log.Info("Creating gRPC client...")
+	client, err := NewGRPCClient(f)
+	if err != nil {
+		return errors.Wrap(err, "could not create gRPC client")
+	}
+	defer client.Close()
+
+	Log.Info("Making GetTopic request...")
+	topic, err := client.fetchTopic(channel)
+	if err == SessionExpiredError {
+		err = f.RefreshSession()
+		if err != nil {
+			return errors.Wrap(err, "could not refresh session")
+		}
+		topic, err = client.fetchTopic(channel)
+	}
+	if err != nil {
+		client.Close()
+		return errors.Wrap(err, "could not fetch topic")
+	}
+
+	if !topic.GetCanPublish() {
+		client.Close()
+		return fmt.Errorf("this user is not allowed to publish to the following topic: %s", channel)
+	}
+
+	for message := range messages {
+		err = client.Publish(channel, message)
+		if err == SessionExpiredError {
+			err = f.RefreshSession()
+			if err != nil {
+				return errors.Wrap(err, "could not refresh session")
+			}
+			err = client.Publish(channel, message)
+		}
+		if err != nil {
+			Log.Info(fmt.Sprintf("error occurred while publishing to topic: %v", err))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Update `pubsub publish` to accept only the channel name as an argument.
If no message is received, stdin is read for messages, which are
published as they are received.  This avoids repeatedly calling GetTopic
and GetSchema.
