### PR TITLE
Fix Source Directory Identification on Windows

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -132,6 +132,7 @@ func runPush(metadataTypes []string, metadataNames []string, resourcePaths []str
 func sourceDirFromPaths(resourcePaths []string) string {
 	p := ""
 	for _, path := range resourcePaths {
+		path = filepath.FromSlash(path)
 		parts := strings.Split(path, string(os.PathSeparator))
 		first := parts[0]
 		if p == "" {


### PR DESCRIPTION
Fixes pushing by path using forward slash as the path separator, such as
with git-bash.
