### PR TITLE
Fix Race in CancelableQueryAndSend

### DIFF
--- a/lib/force.go
+++ b/lib/force.go
@@ -701,6 +701,11 @@ func (f *Force) CancelableQueryAndSend(ctx context.Context, qs string, processor
 	}()
 	select {
 	case <-ctx.Done():
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			// Wait briefly for goroutine to finish before returning and closing the processor channel
+		}
 		return fmt.Errorf("Query cancelled: %w", ctx.Err())
 	case <-done:
 	}


### PR DESCRIPTION
When the context passed to CancelableQueryAndSend is cancelled, wait
briefly for the goroutine to finish before returning an error and
closing the processor channel to avoid having the goroutine send to the
closed channel causing a panic.
