### PR TITLE
Add Smart Flow Deploy Option

### DIFF
--- a/command/smart_flow.go
+++ b/command/smart_flow.go
@@ -1,0 +1,162 @@
+package command
+
+import (
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	. "github.com/ForceCLI/force/lib"
+)
+
+// DestructivePackage represents a destructiveChangesPost.xml structure
+type DestructivePackage struct {
+	XMLName xml.Name          `xml:"Package"`
+	Xmlns   string            `xml:"xmlns,attr"`
+	Types   []DestructiveType `xml:"types"`
+	Version string            `xml:"version"`
+}
+
+// DestructiveType lists metadata members to delete
+type DestructiveType struct {
+	Members []string `xml:"members"`
+	Name    string   `xml:"name"`
+}
+
+// flowQuerier abstracts the Query method needed to fetch flow versions
+type flowQuerier interface {
+	Query(string, ...func(*QueryOptions)) (ForceQueryResult, error)
+}
+
+// processSmartFlowVersion auto-assigns version numbers to unversioned flows
+// and generates a destructiveChangesPost.xml to remove inactive versions.
+func processSmartFlowVersion(q flowQuerier, files ForceMetadataFiles) (ForceMetadataFiles, error) {
+	// Identify local unversioned flows: flows/Name.flow
+	reFlow := regexp.MustCompile(`^flows/([^/]+)\.flow$`)
+	unversioned := map[string]struct{}{}
+	for path := range files {
+		if m := reFlow.FindStringSubmatch(path); m != nil {
+			base := m[1]
+			// skip if base already contains a version suffix
+			if !regexp.MustCompile(`.+-\d+$`).MatchString(base) {
+				unversioned[base] = struct{}{}
+			}
+		}
+	}
+	if len(unversioned) == 0 {
+		return files, nil
+	}
+	// Prepare destructive type
+	var dest DestructiveType
+	dest.Name = "Flow"
+
+	// Track new versioned names for package.xml update
+	newNames := map[string]string{}
+	for name := range unversioned {
+		// Query existing Flow versions via Tooling API
+		soql := fmt.Sprintf("SELECT Status, FlowDefinitionView.ApiName, VersionNumber FROM FlowVersionView WHERE FlowDefinitionView.ApiName = '%s'", name)
+		qr, err := q.Query(soql)
+		if err != nil {
+			return files, fmt.Errorf("query Flow versions for %s: %w", name, err)
+		}
+		existing := map[int]struct{}{}
+		statuses := map[int]string{}
+		for _, rec := range qr.Records {
+			if rec["VersionNumber"] == nil {
+				continue
+			}
+			// VersionNumber comes back as float64
+			vf := rec["VersionNumber"].(float64)
+			v := int(vf)
+			existing[v] = struct{}{}
+			if s, ok := rec["Status"].(string); ok {
+				statuses[v] = s
+			}
+		}
+		// Compute new version: smallest positive integer not in existing
+		newVer := 1
+		for {
+			if _, ok := existing[newVer]; !ok {
+				break
+			}
+			newVer++
+		}
+		// Collect inactive versions for deletion
+		for v, s := range statuses {
+			if s != "Active" {
+				dest.Members = append(dest.Members, fmt.Sprintf("%s-%d", name, v))
+			}
+		}
+		// Record new versioned name and rename local flow files
+		member := fmt.Sprintf("%s-%d", name, newVer)
+		newNames[name] = member
+		// Rename files
+		oldFlow := fmt.Sprintf("flows/%s.flow", name)
+		oldMeta := fmt.Sprintf("flows/%s.flow-meta.xml", name)
+		newFlow := fmt.Sprintf("flows/%s.flow", member)
+		newMeta := fmt.Sprintf("flows/%s.flow-meta.xml", member)
+		if data, ok := files[oldFlow]; ok {
+			files[newFlow] = data
+			delete(files, oldFlow)
+		}
+		// Update package.xml members for Flow entries
+		if pkgXml, ok := files["package.xml"]; ok {
+			// Unmarshal into struct
+			type pkgType struct {
+				Members []string `xml:"members"`
+				Name    string   `xml:"name"`
+			}
+			type pkgStruct struct {
+				XMLName xml.Name  `xml:"Package"`
+				Xmlns   string    `xml:"xmlns,attr"`
+				Types   []pkgType `xml:"types"`
+				Version string    `xml:"version"`
+			}
+			var pkg pkgStruct
+			if err := xml.Unmarshal(pkgXml, &pkg); err == nil {
+				// Replace unversioned member names
+				for ti, t := range pkg.Types {
+					if t.Name == "Flow" {
+						for mi, m := range t.Members {
+							if replacement, found := newNames[m]; found {
+								pkg.Types[ti].Members[mi] = replacement
+							}
+						}
+					}
+				}
+				// Marshal back
+				out, err := xml.MarshalIndent(pkg, "", "    ")
+				if err == nil {
+					out = append([]byte(xml.Header), out...)
+					files["package.xml"] = out
+				}
+			}
+		}
+		if meta, ok := files[oldMeta]; ok {
+			// Update <fullName> tag inside meta xml
+			reFull := regexp.MustCompile(`<fullName>[^<]+</fullName>`)
+			member := fmt.Sprintf("%s-%d", name, newVer)
+			updated := reFull.ReplaceAll(meta, []byte(fmt.Sprintf("<fullName>%s</fullName>", member)))
+			files[newMeta] = updated
+			delete(files, oldMeta)
+		}
+	}
+	// If any inactive versions, generate destructiveChangesPost.xml
+	if len(dest.Members) > 0 {
+		// sort members for consistency
+		sort.Strings(dest.Members)
+		pkg := DestructivePackage{
+			Xmlns:   "http://soap.sforce.com/2006/04/metadata",
+			Types:   []DestructiveType{dest},
+			Version: strings.TrimPrefix(ApiVersion(), "v"),
+		}
+		out, err := xml.MarshalIndent(pkg, "", "    ")
+		if err != nil {
+			return files, fmt.Errorf("marshal destructiveChangesPost: %w", err)
+		}
+		out = append([]byte(xml.Header), out...)
+		files["destructiveChangesPost.xml"] = out
+	}
+	return files, nil
+}

--- a/command/smart_flow_test.go
+++ b/command/smart_flow_test.go
@@ -1,0 +1,174 @@
+package command
+
+import (
+	"encoding/xml"
+	"fmt"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/ForceCLI/force/lib"
+)
+
+// fakeQuerier simulates org queries for flow versions
+type fakeQuerier struct {
+	results map[string]lib.ForceQueryResult
+}
+
+// Test that package.xml members are updated to versioned flow names
+func TestProcessSmartFlowVersion_PackageXmlUpdate(t *testing.T) {
+	name := "MyFlow"
+	// No existing versions => newVer = 1
+	fq := &fakeQuerier{results: map[string]lib.ForceQueryResult{
+		name: {Records: []lib.ForceRecord{}},
+	}}
+	// Sample package.xml with one Flow member
+	pkgXml := []byte(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>%s</members>
+        <name>Flow</name>
+    </types>
+    <version>%s</version>
+</Package>`, name, lib.ApiVersionNumber()))
+	files := lib.ForceMetadataFiles{
+		"flows/MyFlow.flow":          []byte("<flow></flow>"),
+		"flows/MyFlow.flow-meta.xml": []byte("<fullName>MyFlow</fullName>"),
+		"package.xml":                pkgXml,
+	}
+	out, err := processSmartFlowVersion(fq, files)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	updated, ok := out["package.xml"]
+	if !ok {
+		t.Fatalf("package.xml missing after processing")
+	}
+	// Unmarshal and verify member name updated
+	type pkgType struct {
+		Members []string `xml:"members"`
+		Name    string   `xml:"name"`
+	}
+	type pkgStruct struct {
+		Types []pkgType `xml:"types"`
+	}
+	var pkg pkgStruct
+	if err := xml.Unmarshal(updated, &pkg); err != nil {
+		t.Fatalf("failed to parse updated package.xml: %v", err)
+	}
+	found := false
+	for _, tpe := range pkg.Types {
+		if tpe.Name == "Flow" {
+			for _, m := range tpe.Members {
+				if m == "MyFlow-1" {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected member MyFlow-1 in package.xml, got: %s", string(updated))
+	}
+}
+
+func (f *fakeQuerier) Query(_ string, _ ...func(*lib.QueryOptions)) (lib.ForceQueryResult, error) {
+	// Return the first available result
+	for _, res := range f.results {
+		return res, nil
+	}
+	return lib.ForceQueryResult{}, nil
+}
+
+// Test no flows present: files unchanged
+func TestProcessSmartFlowVersion_NoFlows(t *testing.T) {
+	fq := &fakeQuerier{results: map[string]lib.ForceQueryResult{}}
+	files := lib.ForceMetadataFiles{
+		"classes/MyClass.cls": []byte("class MyClass {}"),
+	}
+	out, err := processSmartFlowVersion(fq, files)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(out, files) {
+		t.Errorf("expected files unchanged, got %v", out)
+	}
+}
+
+// Test single active version: should assign next version, no destructiveChangesPost.xml
+func TestProcessSmartFlowVersion_SingleActive(t *testing.T) {
+	name := "MyFlow"
+	fq := &fakeQuerier{results: map[string]lib.ForceQueryResult{
+		name: {Records: []lib.ForceRecord{{"VersionNumber": float64(1), "Status": "Active"}}},
+	}}
+	files := lib.ForceMetadataFiles{
+		"flows/MyFlow.flow":          []byte("<flow></flow>"),
+		"flows/MyFlow.flow-meta.xml": []byte("<fullName>MyFlow</fullName>"),
+	}
+	out, err := processSmartFlowVersion(fq, files)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect new version 2
+	if _, ok := out["flows/MyFlow-2.flow"]; !ok {
+		t.Errorf("missing new flow file")
+	}
+	// Expect meta fullName updated
+	meta, ok := out["flows/MyFlow-2.flow-meta.xml"]
+	if !ok {
+		t.Fatalf("missing new meta file")
+	}
+	if !regexp.MustCompile(`<fullName>MyFlow-2</fullName>`).Match(meta) {
+		t.Errorf("meta fullName not updated, got %s", meta)
+	}
+	// No destructiveChangesPost.xml
+	if _, ok = out["destructiveChangesPost.xml"]; ok {
+		t.Errorf("unexpected destructiveChangesPost.xml")
+	}
+}
+
+// Test mixed versions: inactive and active
+func TestProcessSmartFlowVersion_InactiveAndActive(t *testing.T) {
+	name := "MyFlow"
+	fq := &fakeQuerier{results: map[string]lib.ForceQueryResult{
+		name: {Records: []lib.ForceRecord{
+			{"VersionNumber": float64(2), "Status": "Inactive"},
+			{"VersionNumber": float64(3), "Status": "Active"},
+		}},
+	}}
+	files := lib.ForceMetadataFiles{
+		"flows/MyFlow.flow":          []byte("<flow></flow>"),
+		"flows/MyFlow.flow-meta.xml": []byte("<fullName>MyFlow</fullName>"),
+	}
+	out, err := processSmartFlowVersion(fq, files)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// New version should be 1
+	if _, ok := out["flows/MyFlow-1.flow"]; !ok {
+		t.Errorf("missing new flow version 1")
+	}
+	// Expect destructiveChangesPost.xml with MyFlow-2 only
+	dc, ok := out["destructiveChangesPost.xml"]
+	if !ok {
+		t.Fatalf("missing destructiveChangesPost.xml")
+	}
+	var pkg struct {
+		Types []struct {
+			Members []string `xml:"members"`
+		} `xml:"types"`
+	}
+	if err := xml.Unmarshal(dc, &pkg); err != nil {
+		t.Fatalf("unmarshal dc xml: %v", err)
+	}
+	found := false
+	for _, typ := range pkg.Types {
+		for _, m := range typ.Members {
+			if m == "MyFlow-2" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("destructiveChangesPost missing MyFlow-2, got %s", string(dc))
+	}
+}


### PR DESCRIPTION
Add --smart-flow-version flag to push and import commands to enable
automatic selection of the next flow version and deletion of inactive
versions.  This results in there only being two version of the flow in
the org, the newly deployed version and the previously deployed version.

The lowest available version number will be used.  For example, if
versions 2 and 3 are in the org, and 3 is active, the new version will
be 1, and version 2 will be deleted.
