### PR TITLE
Add --port Flag to `login` Command

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -23,6 +23,7 @@ func init() {
 	loginCmd.Flags().StringP("instance", "i", "", `Defaults to 'login' or last
 logged in system. non-production server to login to (values are 'pre',
 'test', or full instance url`)
+	loginCmd.Flags().IntP("port", "P", 3835, "port for local OAuth callback server")
 
 	scratchCmd.Flags().String("username", "", "username for scratch org user")
 
@@ -55,6 +56,7 @@ to get a new session token automatically when needed.`,
     force login -i my-domain.my.salesforce.com -s[kipLogin]
     force login --connected-app-client-id <my-consumer-key> -u user@example.com -key jwt.key
     force login --connected-app-client-id <my-consumer-key> --connected-app-client-secret <my-consumer-secret>
+    force login -P 8080
     force login scratch
 `,
 	Args: cobra.MaximumNArgs(0),
@@ -72,7 +74,8 @@ to get a new session token automatically when needed.`,
 			clientCredentialsLogin(endpoint, ClientId, clientSecret)
 		case username == "":
 			skipLogin, _ := cmd.Flags().GetBool("skip")
-			oauthLogin(endpoint, skipLogin)
+			port, _ := cmd.Flags().GetInt("port")
+			oauthLogin(endpoint, skipLogin, port)
 		case keyFile != "":
 			jwtLogin(endpoint, username, keyFile)
 		default:
@@ -89,12 +92,12 @@ func scratchLogin(scratchUser string) {
 	}
 }
 
-func oauthLogin(endpoint string, skipLogin bool) {
+func oauthLogin(endpoint string, skipLogin bool, port int) {
 	var err error
 	if skipLogin {
-		_, err = ForceLoginAtEndpointWithPromptAndSave(endpoint, os.Stdout, "consent")
+		_, err = ForceLoginAtEndpointWithPromptAndSaveWithPort(endpoint, os.Stdout, "consent", port)
 	} else {
-		_, err = ForceLoginAtEndpointAndSave(endpoint, os.Stdout)
+		_, err = ForceLoginAtEndpointAndSaveWithPort(endpoint, os.Stdout, port)
 	}
 	if err != nil {
 		ErrorAndExit(err.Error())

--- a/lib/auth.go
+++ b/lib/auth.go
@@ -141,8 +141,21 @@ func ForceLoginAtEndpointAndSave(endpoint string, output *os.File) (username str
 	return ForceLoginAtEndpointWithPromptAndSave(endpoint, output, "login")
 }
 
+func ForceLoginAtEndpointAndSaveWithPort(endpoint string, output *os.File, port int) (username string, err error) {
+	return ForceLoginAtEndpointWithPromptAndSaveWithPort(endpoint, output, "login", port)
+}
+
 func ForceLoginAtEndpointWithPromptAndSave(endpoint string, output *os.File, prompt string) (username string, err error) {
 	creds, err := ForceLoginAtEndpointWithPrompt(endpoint, prompt)
+	if err != nil {
+		return
+	}
+	username, err = ForceSaveLogin(creds, output)
+	return
+}
+
+func ForceLoginAtEndpointWithPromptAndSaveWithPort(endpoint string, output *os.File, prompt string, port int) (username string, err error) {
+	creds, err := ForceLoginAtEndpointWithPromptAndPort(endpoint, prompt, port)
 	if err != nil {
 		return
 	}

--- a/lib/force.go
+++ b/lib/force.go
@@ -388,11 +388,15 @@ func ForceLogin(endpoint ForceEndpoint) (creds ForceSession, err error) {
 }
 
 func ForceLoginAtEndpointWithPrompt(endpoint string, prompt string) (creds ForceSession, err error) {
+	return ForceLoginAtEndpointWithPromptAndPort(endpoint, prompt, 3835)
+}
+
+func ForceLoginAtEndpointWithPromptAndPort(endpoint string, prompt string, targetPort int) (creds ForceSession, err error) {
 	ch := make(chan ForceSession)
-	port, err := startLocalHttpServer(ch)
+	port, err := startLocalHttpServerWithPort(ch, targetPort)
 	var url string
 
-	Redir := RedirectUri
+	Redir := fmt.Sprintf("http://localhost:%d/oauth/callback", port)
 
 	url = fmt.Sprintf("%s/services/oauth2/authorize?response_type=token&client_id=%s&redirect_uri=%s&state=%d&prompt=%s", endpoint, ClientId, Redir, port, prompt)
 
@@ -1544,7 +1548,11 @@ func (result *ForceQueryResult) Update(other ForceQueryResult, force *Force) {
 }
 
 func startLocalHttpServer(ch chan ForceSession) (port int, err error) {
-	listener, err := net.Listen("tcp", ":3835")
+	return startLocalHttpServerWithPort(ch, 3835)
+}
+
+func startLocalHttpServerWithPort(ch chan ForceSession, targetPort int) (port int, err error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", targetPort))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Add --port flag to `login` command to override the default port, useful
when using a Connected App with --connected-app-client-id that is
configured for a different callback url on localhost than the default.
