### PR TITLE
Improve picklist field creation debug output

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -901,9 +901,8 @@ func (fm *ForceMetadata) CreateCustomField(object, field, typ string, options ma
 	case "picklist":
 		soapField = "<type>Picklist</type>\n"
 		for key, value := range options {
-			fmt.Println("Options: ", options)
-			fmt.Println(fmt.Sprintf("Key %s", key))
 			if key == "picklist>picklistValues" {
+				fmt.Printf("Creating picklist with values: %s\n", value)
 				soapField += "<picklist>\n"
 				for _, k := range strings.Split(value, ",") {
 					soapField += fmt.Sprintf("<picklistValues>\n<fullName>%s</fullName>\n<default>false</default>\n</picklistValues>\n", strings.Trim(k, " "))


### PR DESCRIPTION
## Summary
- Improved debug output during picklist field creation to be more user-friendly
- Replaced unclear raw Go map output with clear, descriptive messages
- Enhanced user experience when creating picklist fields

## Issue
Fixes #324

## Problem Description  
When creating picklist fields, the debug output was confusing and showed raw Go data structures:

```
$ ./force field create Airplanes__c "Final Outcome":picklist picklist:"Pass, Fail, Redo"
Options:  map[picklist>picklistValues:Pass, Fail, Redo]
Key picklist>picklistValues
Custom field created
```

Users found this output "not very clear" as it exposed internal implementation details.

## Solution
Replaced the unclear debug messages with user-friendly output:

**Before:**
```
Options:  map[picklist>picklistValues:Pass, Fail, Redo]
Key picklist>picklistValues
```

**After:**
```
Creating picklist with values: Pass, Fail, Redo
```

## Changes Made
- **lib/metadata.go**: Updated picklist creation debug output in `CreateCustomField()` method
- Removed raw map output and verbose key logging
- Added clear, descriptive message showing what values are being configured

## Benefits
1. **Better UX**: Users see clear, understandable messages instead of internal data structures
2. **Less verbose**: Eliminates redundant key logging that printed for every option
3. **More informative**: Clearly communicates what the command is doing
4. **Professional output**: Hides implementation details from end users

## Test Plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] No functional changes to picklist creation logic
- [x] Only the display output is improved

🤖 Generated with [Claude Code](https://claude.ai/code)