### PR TITLE
Update to Go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.24
     steps:
       - checkout
       - run: go install github.com/mitchellh/gox@v1.0.1

--- a/command/active.go
+++ b/command/active.go
@@ -50,7 +50,7 @@ func printCurrentAccount(cmd *cobra.Command) {
 	if sessionId {
 		fmt.Println(creds.AccessToken)
 	} else if tojson {
-		fmt.Printf(fmt.Sprintf(`{ "login": "%s", "instanceUrl": "%s", "namespace": "%s", "orgId": "%s" }`, creds.SessionName(), creds.InstanceUrl, creds.UserInfo.OrgNamespace, creds.UserInfo.OrgId))
+		fmt.Printf(`{ "login": "%s", "instanceUrl": "%s", "namespace": "%s", "orgId": "%s" }`, creds.SessionName(), creds.InstanceUrl, creds.UserInfo.OrgNamespace, creds.UserInfo.OrgId)
 	} else {
 		fmt.Println(fmt.Sprintf("%s - %s - Org: %s - ns:%s", creds.SessionName(), creds.InstanceUrl, creds.UserInfo.OrgId, creds.UserInfo.OrgNamespace))
 	}
@@ -65,7 +65,7 @@ func setAccount(account string, local bool) {
 			cmd.Run()
 		} else {
 			title := fmt.Sprintf("\033];%s\007", account)
-			fmt.Printf(title)
+			fmt.Print(title)
 		}
 		fmt.Printf("%s now active\n", account)
 		if local {

--- a/command/logout.go
+++ b/command/logout.go
@@ -41,6 +41,6 @@ func runLogout() {
 		cmd.Run()
 	} else {
 		title := fmt.Sprintf("\033];%s\007", "")
-		fmt.Printf(title)
+		fmt.Print(title)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ForceCLI/force
 
-go 1.20
+go 1.24
 
 require (
 	github.com/ForceCLI/config v0.0.0-20230217143549-9149d42a3c99

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=

--- a/lib/bulk.go
+++ b/lib/bulk.go
@@ -65,7 +65,7 @@ func (ji JobInfo) JobContentType() (JobContentType, error) {
 	case "XML":
 		return JobContentTypeXml, nil
 	default:
-		return "", fmt.Errorf("Invalid content type for bulk API: " + ji.ContentType)
+		return "", fmt.Errorf("Invalid content type for bulk API: %s", ji.ContentType)
 	}
 }
 

--- a/lib/display.go
+++ b/lib/display.go
@@ -628,7 +628,7 @@ func DisplayFieldDetails(fieldType string) {
   Sorry, that is not a valid field type.
 `
 	}
-	fmt.Printf(msg + "\n")
+	fmt.Println(msg)
 }
 
 func DisplayTextFieldDetails() (message string) {

--- a/lib/pubsub/grpcclient.go
+++ b/lib/pubsub/grpcclient.go
@@ -356,7 +356,7 @@ func (c *PubSubClient) Publish(channel string, message map[string]any) error {
 	}
 
 	if err := result[0].GetError(); err != nil {
-		return fmt.Errorf(result[0].GetError().GetMsg())
+		return errors.New(result[0].GetError().GetMsg())
 	}
 
 	return nil


### PR DESCRIPTION
Update Go version to support slices package from standard library,
needed by jwt package.

Update fmt function calls to fix invalid format strings.
