### PR TITLE
Use Version Number for Name and Description By Default

### DIFF
--- a/command/package.go
+++ b/command/package.go
@@ -37,15 +37,13 @@ func init() {
 	packageVersionCreateCmd.Flags().StringP("package-id", "i", "", "Package ID (required if --namespace not provided)")
 	packageVersionCreateCmd.Flags().StringP("namespace", "", "", "Package namespace (alternative to --package-id)")
 	packageVersionCreateCmd.Flags().StringP("version-number", "n", "", "Version number (required, e.g., 1.0.0.0)")
-	packageVersionCreateCmd.Flags().StringP("version-name", "m", "", "Version name (required)")
-	packageVersionCreateCmd.Flags().StringP("version-description", "d", "", "Version description (required)")
+	packageVersionCreateCmd.Flags().StringP("version-name", "m", "", "Version name (optional, defaults to version-number)")
+	packageVersionCreateCmd.Flags().StringP("version-description", "d", "", "Version description (optional, defaults to version-number)")
 	packageVersionCreateCmd.Flags().StringP("ancestor-id", "", "", "Ancestor version ID (optional)")
 	packageVersionCreateCmd.Flags().BoolP("skip-validation", "s", false, "Skip validation")
 	packageVersionCreateCmd.Flags().BoolP("async-validation", "y", false, "Async validation")
 	packageVersionCreateCmd.Flags().BoolP("code-coverage", "c", true, "Calculate code coverage")
 	packageVersionCreateCmd.MarkFlagRequired("version-number")
-	packageVersionCreateCmd.MarkFlagRequired("version-name")
-	packageVersionCreateCmd.MarkFlagRequired("version-description")
 
 	packageVersionReleaseCmd.Flags().StringP("version-id", "v", "", "Package Version ID (required)")
 	packageVersionReleaseCmd.MarkFlagRequired("version-id")
@@ -554,6 +552,14 @@ func pollPackageUninstallStatus(requestId string) {
 func runCreatePackageVersion(path string, packageId string, namespace string, versionNumber string,
 	versionName string, versionDescription string, ancestorId string,
 	skipValidation bool, asyncValidation bool, codeCoverage bool) {
+
+	// Use version-number as default for version-name and version-description if not provided
+	if versionName == "" {
+		versionName = versionNumber
+	}
+	if versionDescription == "" {
+		versionDescription = versionNumber
+	}
 
 	// Validate that either package-id or namespace is provided
 	if packageId == "" && namespace == "" {

--- a/command/package_test.go
+++ b/command/package_test.go
@@ -8,7 +8,7 @@ func Test_package_version_create_command_requires_flags(t *testing.T) {
 	cmd := packageVersionCreateCmd
 
 	// Test that required flags are marked as required (package-id is no longer required since namespace is an alternative)
-	requiredFlags := []string{"version-number", "version-name", "version-description"}
+	requiredFlags := []string{"version-number"}
 
 	for _, flagName := range requiredFlags {
 		flag := cmd.Flags().Lookup(flagName)
@@ -49,7 +49,7 @@ func Test_package_version_create_command_has_optional_flags(t *testing.T) {
 	cmd := packageVersionCreateCmd
 
 	// Test that optional flags exist
-	optionalFlags := []string{"ancestor-id", "skip-validation", "async-validation", "code-coverage"}
+	optionalFlags := []string{"version-name", "version-description", "ancestor-id", "skip-validation", "async-validation", "code-coverage"}
 
 	for _, flagName := range optionalFlags {
 		flag := cmd.Flags().Lookup(flagName)


### PR DESCRIPTION
Update `package version create` to use the version number as the version
name and description by default.
