### PR TITLE
Add Order Management Support To `login scratch` Command

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -35,6 +35,7 @@ const (
 	ServiceCloud
 	ScvMultipartyAndConsult
 	ServiceCloudVoicePartnerTelephony
+	OrderManagement
 )
 
 var ScratchFeatureIds = map[ScratchFeature][]string{
@@ -57,6 +58,7 @@ var ScratchFeatureIds = map[ScratchFeature][]string{
 	ServiceCloud:                      {"ServiceCloud"},
 	ScvMultipartyAndConsult:           {"ScvMultipartyAndConsult"},
 	ServiceCloudVoicePartnerTelephony: {"ServiceCloudVoicePartnerTelephony"},
+	OrderManagement:                   {"OrderManagement"},
 }
 
 type ScratchProduct enumflag.Flag
@@ -111,6 +113,8 @@ const (
 	EnableApexApprovalLockUnlock
 	PermsetsInFieldCreation
 	EnableLightningPreviewPref
+	EnableOrders
+	EnableEnhancedCommerceOrders
 )
 
 var ScratchSettingIds = map[ScratchSetting][]string{
@@ -121,6 +125,8 @@ var ScratchSettingIds = map[ScratchSetting][]string{
 	EnableApexApprovalLockUnlock: {"enableApexApprovalLockUnlock"},
 	PermsetsInFieldCreation:      {"permsetsInFieldCreation"},
 	EnableLightningPreviewPref:   {"enableLightningPreviewPref"},
+	EnableOrders:                 {"enableOrders"},
+	EnableEnhancedCommerceOrders: {"enableEnhancedCommerceOrders"},
 }
 
 type ScratchRelease enumflag.Flag
@@ -216,6 +222,7 @@ Available Features:
   HealthCloudAddOn                    - Enables Health Cloud add-on
   HealthCloudUser                     - Enables Health Cloud user licenses
   InsightsPlatform                    - Enables Insights Platform
+  OrderManagement                     - Enables Salesforce Order Management
   PersonAccounts                      - Enables Person Accounts (B2C account model)
   ScvMultipartyAndConsult             - Enables Service Cloud Voice multiparty and consult (requires quantity, default: 10)
   ServiceCloud                        - Enables Service Cloud
@@ -224,7 +231,7 @@ Available Features:
   WavePlatform                        - Enables Wave Platform (CRM Analytics)
 
 Available Products:
-  b2bcommerce - B2B Commerce (enables B2BCommerce feature and commerceEnabled setting)
+  b2bcommerce  - B2B Commerce (enables B2BCommerce, OrderManagement features and commerceEnabled, enableOrders, enableEnhancedCommerceOrders settings)
   communities  - Experience Cloud (enables Communities feature and networksEnabled setting)
   crmanalytics - CRM Analytics (enables AnalyticsAdminPerms, WavePlatform, InsightsPlatform, EinsteinAnalyticsPlus, EinsteinBuilderFree, DevelopmentWave)
   fsc          - Financial Services Cloud (enables PersonAccounts, ContactsToMultipleAccounts, FinancialServicesUser)
@@ -248,6 +255,8 @@ Available Settings (deployed after org creation):
   enableApexApprovalLockUnlock - Allow Apex to lock/unlock approval processes
   permsetsInFieldCreation - Allow assigning permission sets during field creation
   enableLightningPreviewPref - Enable Lightning Experience preview pref
+  enableOrders - Enable Orders
+  enableEnhancedCommerceOrders - Enable Enhanced Commerce Orders
 
 Available Releases:
   preview  - Create scratch org on the next (preview) release
@@ -338,7 +347,7 @@ func expandProductsToFeatures(products []ScratchProduct, features []ScratchFeatu
 		CommunitiesProduct:  {Communities},
 		HealthCloudProduct:  {HealthCloudAddOn, HealthCloudUser},
 		CRMAnalyticsProduct: {AnalyticsAdminPerms, WavePlatform, InsightsPlatform, EinsteinAnalyticsPlus, EinsteinBuilderFree, DevelopmentWave},
-		B2BCommerceProduct:  {B2BCommerce},
+		B2BCommerceProduct:  {B2BCommerce, OrderManagement},
 	}
 
 	featureSet := make(map[ScratchFeature]bool)
@@ -382,7 +391,7 @@ func convertSettingsToStrings(settings []ScratchSetting) []string {
 func expandProductsToSettings(products []ScratchProduct, settings []ScratchSetting) []string {
 	productSettings := map[ScratchProduct][]ScratchSetting{
 		CommunitiesProduct: {NetworksEnabled},
-		B2BCommerceProduct: {CommerceEnabled},
+		B2BCommerceProduct: {CommerceEnabled, EnableOrders, EnableEnhancedCommerceOrders},
 	}
 
 	settingSet := make(map[ScratchSetting]bool)

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -174,11 +174,18 @@ func TestExpandProductsToFeatures_CommunitiesProduct(t *testing.T) {
 
 func TestExpandProductsToFeatures_B2BCommerceProduct(t *testing.T) {
 	result := expandProductsToFeatures([]ScratchProduct{B2BCommerceProduct}, []ScratchFeature{}, map[string]string{})
-	if len(result) != 1 {
-		t.Errorf("Expected 1 feature from b2bcommerce product, got %d", len(result))
+	if len(result) != 2 {
+		t.Errorf("Expected 2 features from b2bcommerce product, got %d", len(result))
 	}
-	if result[0] != "B2BCommerce" {
-		t.Errorf("Expected B2BCommerce, got %s", result[0])
+	featureMap := make(map[string]bool)
+	for _, f := range result {
+		featureMap[f] = true
+	}
+	if !featureMap["B2BCommerce"] {
+		t.Error("Expected B2BCommerce in b2bcommerce product")
+	}
+	if !featureMap["OrderManagement"] {
+		t.Error("Expected OrderManagement in b2bcommerce product")
 	}
 }
 
@@ -248,11 +255,21 @@ func TestExpandProductsToSettings_CommunitiesProduct(t *testing.T) {
 
 func TestExpandProductsToSettings_B2BCommerceProduct(t *testing.T) {
 	result := expandProductsToSettings([]ScratchProduct{B2BCommerceProduct}, []ScratchSetting{})
-	if len(result) != 1 {
-		t.Errorf("Expected 1 setting from b2bcommerce product, got %d", len(result))
+	if len(result) != 3 {
+		t.Errorf("Expected 3 settings from b2bcommerce product, got %d", len(result))
 	}
-	if result[0] != "commerceEnabled" {
-		t.Errorf("Expected commerceEnabled, got %s", result[0])
+	settingMap := make(map[string]bool)
+	for _, s := range result {
+		settingMap[s] = true
+	}
+	if !settingMap["commerceEnabled"] {
+		t.Error("Expected commerceEnabled in b2bcommerce product")
+	}
+	if !settingMap["enableOrders"] {
+		t.Error("Expected enableOrders in b2bcommerce product")
+	}
+	if !settingMap["enableEnhancedCommerceOrders"] {
+		t.Error("Expected enableEnhancedCommerceOrders in b2bcommerce product")
 	}
 }
 
@@ -326,6 +343,7 @@ func TestScratchFeatureIds_AllFeaturesDefined(t *testing.T) {
 		"HealthCloudAddOn":                  true,
 		"HealthCloudUser":                   true,
 		"InsightsPlatform":                  true,
+		"OrderManagement":                   true,
 		"PersonAccounts":                    true,
 		"ScvMultipartyAndConsult":           true,
 		"ServiceCloud":                      true,
@@ -436,6 +454,8 @@ func TestScratchSettingIds_AllSettingsDefined(t *testing.T) {
 		"enableApexApprovalLockUnlock": true,
 		"permsetsInFieldCreation":      true,
 		"enableLightningPreviewPref":   true,
+		"enableOrders":                 true,
+		"enableEnhancedCommerceOrders": true,
 	}
 
 	if len(ScratchSettingIds) != len(expectedSettings) {

--- a/docs/force_login_scratch.md
+++ b/docs/force_login_scratch.md
@@ -20,6 +20,7 @@ Available Features:
   HealthCloudAddOn                    - Enables Health Cloud add-on
   HealthCloudUser                     - Enables Health Cloud user licenses
   InsightsPlatform                    - Enables Insights Platform
+  OrderManagement                     - Enables Salesforce Order Management
   PersonAccounts                      - Enables Person Accounts (B2C account model)
   ScvMultipartyAndConsult             - Enables Service Cloud Voice multiparty and consult (requires quantity, default: 10)
   ServiceCloud                        - Enables Service Cloud
@@ -28,7 +29,7 @@ Available Features:
   WavePlatform                        - Enables Wave Platform (CRM Analytics)
 
 Available Products:
-  b2bcommerce - B2B Commerce (enables B2BCommerce feature and commerceEnabled setting)
+  b2bcommerce  - B2B Commerce (enables B2BCommerce, OrderManagement features and commerceEnabled, enableOrders, enableEnhancedCommerceOrders settings)
   communities  - Experience Cloud (enables Communities feature and networksEnabled setting)
   crmanalytics - CRM Analytics (enables AnalyticsAdminPerms, WavePlatform, InsightsPlatform, EinsteinAnalyticsPlus, EinsteinBuilderFree, DevelopmentWave)
   fsc          - Financial Services Cloud (enables PersonAccounts, ContactsToMultipleAccounts, FinancialServicesUser)
@@ -52,6 +53,8 @@ Available Settings (deployed after org creation):
   enableApexApprovalLockUnlock - Allow Apex to lock/unlock approval processes
   permsetsInFieldCreation - Allow assigning permission sets during field creation
   enableLightningPreviewPref - Enable Lightning Experience preview pref
+  enableOrders - Enable Orders
+  enableEnhancedCommerceOrders - Enable Enhanced Commerce Orders
 
 Available Releases:
   preview  - Create scratch org on the next (preview) release

--- a/lib/scratch.go
+++ b/lib/scratch.go
@@ -207,6 +207,7 @@ func buildSettingsMetadata(settings []string) ForceMetadataFiles {
 	userManagementSettings := false
 	lightningExperienceSettings := false
 	commerceSettings := false
+	orderSettings := false
 
 	for _, setting := range settings {
 		switch setting {
@@ -231,6 +232,8 @@ func buildSettingsMetadata(settings []string) ForceMetadataFiles {
 			files["unpackaged/settings/Communities.settings"] = []byte(communitiesSettings)
 		case "commerceEnabled":
 			commerceSettings = true
+		case "enableOrders", "enableEnhancedCommerceOrders":
+			orderSettings = true
 		case "enableApexApprovalLockUnlock":
 			apexSettings = true
 		case "permsetsInFieldCreation":
@@ -274,6 +277,16 @@ func buildSettingsMetadata(settings []string) ForceMetadataFiles {
     <commerceEnabled>true</commerceEnabled>
 </CommerceSettings>`)
 		files["unpackaged/settings/Commerce.settings"] = commerceBuffer.Bytes()
+	}
+
+	if orderSettings {
+		var orderBuffer bytes.Buffer
+		orderBuffer.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<OrderSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <enableOrders>true</enableOrders>
+    <enableEnhancedCommerceOrders>true</enableEnhancedCommerceOrders>
+</OrderSettings>`)
+		files["unpackaged/settings/Order.settings"] = orderBuffer.Bytes()
 	}
 
 	return files

--- a/lib/scratch_test.go
+++ b/lib/scratch_test.go
@@ -92,6 +92,47 @@ func TestBuildSettingsMetadata_ExcludesCommerceSettingsWhenUnused(t *testing.T) 
 	}
 }
 
+func TestBuildSettingsMetadata_AddsOrderSettings_for_enableOrders(t *testing.T) {
+	files := buildSettingsMetadata([]string{"enableOrders"})
+
+	content, ok := files["unpackaged/settings/Order.settings"]
+	if !ok {
+		t.Fatalf("Order.settings not generated")
+	}
+	if !strings.Contains(string(content), "<enableOrders>true</enableOrders>") {
+		t.Errorf("Order.settings missing enableOrders preference:\n%s", content)
+	}
+	if !strings.Contains(string(content), "<enableEnhancedCommerceOrders>true</enableEnhancedCommerceOrders>") {
+		t.Errorf("Order.settings missing enableEnhancedCommerceOrders preference:\n%s", content)
+	}
+	if !strings.Contains(string(content), "<OrderSettings ") {
+		t.Errorf("Order.settings missing OrderSettings metadata type:\n%s", content)
+	}
+}
+
+func TestBuildSettingsMetadata_AddsOrderSettings_for_enableEnhancedCommerceOrders(t *testing.T) {
+	files := buildSettingsMetadata([]string{"enableEnhancedCommerceOrders"})
+
+	content, ok := files["unpackaged/settings/Order.settings"]
+	if !ok {
+		t.Fatalf("Order.settings not generated")
+	}
+	if !strings.Contains(string(content), "<enableOrders>true</enableOrders>") {
+		t.Errorf("Order.settings missing enableOrders preference:\n%s", content)
+	}
+	if !strings.Contains(string(content), "<enableEnhancedCommerceOrders>true</enableEnhancedCommerceOrders>") {
+		t.Errorf("Order.settings missing enableEnhancedCommerceOrders preference:\n%s", content)
+	}
+}
+
+func TestBuildSettingsMetadata_ExcludesOrderSettingsWhenUnused(t *testing.T) {
+	files := buildSettingsMetadata([]string{"enableEnhancedNotes"})
+
+	if _, ok := files["unpackaged/settings/Order.settings"]; ok {
+		t.Fatalf("Order.settings should not be generated when not requested")
+	}
+}
+
 func TestGetScratchOrg_returns_error_when_SignupUsername_is_nil(t *testing.T) {
 	f := &Force{}
 	f.Credentials = &ForceSession{}


### PR DESCRIPTION
Add OrderManagement as a --feature option and enableOrders/enableEnhancedCommerceOrders
as --setting options. Both order settings deploy via OrderSettings metadata.

Update b2bcommerce product to include OrderManagement feature and order settings
automatically.
